### PR TITLE
Support reference-guided image editing

### DIFF
--- a/examples/dataset.toml
+++ b/examples/dataset.toml
@@ -46,7 +46,12 @@ frame_buckets = [1, 33]
 [[directory]]
 # Path to directory of images/videos, and corresponding caption files. The caption files should match the media file name, but with a .txt extension.
 # A missing caption file will log a warning, but then just train using an empty caption.
-path = '/home/anon/data/images/grayscale'
+path = "/home/anon/data/images/grayscale"
+# For edit datasets that take a source image and a separate reference image
+# (used instead of a text prompt), specify the following optional paths.  Each
+# file in these directories must share the same stem as the images in ``path``.
+# source_path = '/home/anon/data/images/grayscale/source'
+# reference_path = '/home/anon/data/images/grayscale/reference'
 
 # You can do masked training, where the mask indicates which parts of the image to train on. The masking is done in the loss function. The mask directory should have mask
 # images with the same names (ignoring the extension) as the training images. E.g. training image 1.jpg could have mask image 1.jpg, 1.png, etc. If a training image doesn't
@@ -54,7 +59,7 @@ path = '/home/anon/data/images/grayscale'
 # in between black and white become a weight between 0 and 1, i.e. you can use a suitable value of grey for mask weight of 0.5. In actuality, only the R channel is extracted
 # and converted to the mask weight.
 # The mask_path can point to any directory containing mask images.
-#mask_path = '/home/anon/data/images/grayscale/masks'
+# mask_path = '/home/anon/data/images/grayscale/masks'
 
 # How many repeats for 1 epoch. The dataset will act like it is duplicated this many times.
 # The semantics of this are the same as sd-scripts: num_repeats=1 means one epoch is a single pass over all examples (no duplication).

--- a/models/qwen_image.py
+++ b/models/qwen_image.py
@@ -16,11 +16,16 @@ import transformers
 from PIL import Image, ImageOps
 
 from models.base import BasePipeline, PreprocessMediaFile, make_contiguous
-from utils.common import AUTOCAST_DTYPE, get_lin_function, time_shift, iterate_safetensors
+from utils.common import (
+    AUTOCAST_DTYPE,
+    get_lin_function,
+    time_shift,
+    iterate_safetensors,
+)
 from utils.offloading import ModelOffloader
 
 
-KEEP_IN_HIGH_PRECISION = ['time_text_embed', 'img_in', 'txt_in', 'norm_out', 'proj_out']
+KEEP_IN_HIGH_PRECISION = ["time_text_embed", "img_in", "txt_in", "norm_out", "proj_out"]
 
 
 def apply_rotary_emb_qwen(
@@ -51,14 +56,20 @@ def apply_rotary_emb_qwen(
 
         if use_real_unbind_dim == -1:
             # Used for flux, cogvideox, hunyuan-dit
-            x_real, x_imag = x.reshape(*x.shape[:-1], -1, 2).unbind(-1)  # [B, S, H, D//2]
+            x_real, x_imag = x.reshape(*x.shape[:-1], -1, 2).unbind(
+                -1
+            )  # [B, S, H, D//2]
             x_rotated = torch.stack([-x_imag, x_real], dim=-1).flatten(3)
         elif use_real_unbind_dim == -2:
             # Used for Stable Audio, OmniGen, CogView4 and Cosmos
-            x_real, x_imag = x.reshape(*x.shape[:-1], 2, -1).unbind(-2)  # [B, S, H, D//2]
+            x_real, x_imag = x.reshape(*x.shape[:-1], 2, -1).unbind(
+                -2
+            )  # [B, S, H, D//2]
             x_rotated = torch.cat([-x_imag, x_real], dim=-1)
         else:
-            raise ValueError(f"`use_real_unbind_dim={use_real_unbind_dim}` but should be -1 or -2.")
+            raise ValueError(
+                f"`use_real_unbind_dim={use_real_unbind_dim}` but should be -1 or -2."
+            )
 
         out = (x.float() * cos + x_rotated.float() * sin).to(x.dtype)
 
@@ -98,7 +109,9 @@ class QwenDoubleStreamAttnProcessor2_0:
         image_rotary_emb: Optional[torch.Tensor] = None,
     ) -> torch.FloatTensor:
         if encoder_hidden_states is None:
-            raise ValueError("QwenDoubleStreamAttnProcessor2_0 requires encoder_hidden_states (text stream)")
+            raise ValueError(
+                "QwenDoubleStreamAttnProcessor2_0 requires encoder_hidden_states (text stream)"
+            )
 
         seq_txt = encoder_hidden_states.shape[1]
 
@@ -175,9 +188,9 @@ class QwenDoubleStreamAttnProcessor2_0:
 
 
 class QwenImagePipeline(BasePipeline):
-    name = 'qwen_image'
-    checkpointable_layers = ['TransformerLayer']
-    adapter_target_modules = ['QwenImageTransformerBlock']
+    name = "qwen_image"
+    checkpointable_layers = ["TransformerLayer"]
+    adapter_target_modules = ["QwenImageTransformerBlock"]
 
     prompt_template_encode = "<|im_start|>system\nDescribe the image by detailing the color, shape, size, texture, quantity, text, spatial relationships of the objects and background:<|im_end|>\n<|im_start|>user\n{}<|im_end|>\n<|im_start|>assistant\n"
     prompt_template_encode_start_idx = 34
@@ -189,41 +202,59 @@ class QwenImagePipeline(BasePipeline):
 
     def __init__(self, config):
         self.config = config
-        self.model_config = self.config['model']
-        self.offloader = ModelOffloader('dummy', [], 0, 0, True, torch.device('cuda'), False, debug=False)
-        dtype = self.model_config['dtype']
+        self.model_config = self.config["model"]
+        self.offloader = ModelOffloader(
+            "dummy", [], 0, 0, True, torch.device("cuda"), False, debug=False
+        )
+        dtype = self.model_config["dtype"]
 
-        self.preprocess_media_file_fn = PreprocessMediaFile(self.config, support_video=True, framerate=1)
+        self.preprocess_media_file_fn = PreprocessMediaFile(
+            self.config, support_video=True, framerate=1
+        )
 
-        tokenizer = transformers.Qwen2Tokenizer.from_pretrained('configs/qwen_image/tokenizer', local_files_only=True)
-        processor = transformers.Qwen2VLProcessor.from_pretrained('configs/qwen_image/processor', local_files_only=True)
+        tokenizer = transformers.Qwen2Tokenizer.from_pretrained(
+            "configs/qwen_image/tokenizer", local_files_only=True
+        )
+        processor = transformers.Qwen2VLProcessor.from_pretrained(
+            "configs/qwen_image/processor", local_files_only=True
+        )
 
-        if 'text_encoder_path' in self.model_config:
-            text_encoder_path = self.model_config['text_encoder_path']
+        if "text_encoder_path" in self.model_config:
+            text_encoder_path = self.model_config["text_encoder_path"]
         else:
-            text_encoder_path = Path(self.model_config['diffusers_path']) / 'text_encoder'
-        text_encoder_config = transformers.Qwen2_5_VLConfig.from_pretrained('configs/qwen_image/text_encoder', local_files_only=True)
+            text_encoder_path = (
+                Path(self.model_config["diffusers_path"]) / "text_encoder"
+            )
+        text_encoder_config = transformers.Qwen2_5_VLConfig.from_pretrained(
+            "configs/qwen_image/text_encoder", local_files_only=True
+        )
         with init_empty_weights():
-            text_encoder = transformers.Qwen2_5_VLForConditionalGeneration(text_encoder_config)
+            text_encoder = transformers.Qwen2_5_VLForConditionalGeneration(
+                text_encoder_config
+            )
         for key, tensor in iterate_safetensors(text_encoder_path):
             # The keys in the state_dict don't match the structure in the model. Annoying. Need to convert.
-            key = key.replace('model.', 'language_model.')
-            key = 'model.' + key
-            if 'lm_head' in key:
-                key = 'lm_head.weight'
-            set_module_tensor_to_device(text_encoder, key, device='cpu', dtype=dtype, value=tensor)
+            key = key.replace("model.", "language_model.")
+            key = "model." + key
+            if "lm_head" in key:
+                key = "lm_head.weight"
+            set_module_tensor_to_device(
+                text_encoder, key, device="cpu", dtype=dtype, value=tensor
+            )
 
         # TODO: make this work with ComfyUI VAE weights, which have completely different key names.
-        if 'vae_path' in self.model_config:
-            vae_path = self.model_config['vae_path']
+        if "vae_path" in self.model_config:
+            vae_path = self.model_config["vae_path"]
         else:
-            vae_path = Path(self.model_config['diffusers_path']) / 'vae'
-        with open('configs/qwen_image/vae/config.json') as f:
+            vae_path = Path(self.model_config["diffusers_path"]) / "vae"
+        with open("configs/qwen_image/vae/config.json") as f:
             vae_config = json.load(f)
         with init_empty_weights():
             vae = diffusers.AutoencoderKLQwenImage.from_config(vae_config)
         for key, tensor in iterate_safetensors(vae_path):
-            set_module_tensor_to_device(vae, key, device='cpu', dtype=dtype, value=tensor)
+            set_module_tensor_to_device(
+                vae, key, device="cpu", dtype=dtype, value=tensor
+            )
 
         self.diffusers_pipeline = diffusers.QwenImagePipeline(
             scheduler=None,
@@ -240,27 +271,38 @@ class QwenImagePipeline(BasePipeline):
             .view(1, self.vae.config.z_dim, 1, 1, 1)
             .to(dtype)
         )
-        latents_std = torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(dtype)
-        self.vae.register_buffer('latents_mean_tensor', latents_mean)
-        self.vae.register_buffer('latents_std_tensor', latents_std)
+        latents_std = (
+            torch.tensor(self.vae.config.latents_std)
+            .view(1, self.vae.config.z_dim, 1, 1, 1)
+            .to(dtype)
+        )
+        self.vae.register_buffer("latents_mean_tensor", latents_mean)
+        self.vae.register_buffer("latents_std_tensor", latents_std)
 
     def load_diffusion_model(self):
-        dtype = self.model_config['dtype']
-        transformer_dtype = self.model_config.get('transformer_dtype', dtype)
+        dtype = self.model_config["dtype"]
+        transformer_dtype = self.model_config.get("transformer_dtype", dtype)
 
-        if 'transformer_path' in self.model_config:
-            transformer_path = self.model_config['transformer_path']
+        if "transformer_path" in self.model_config:
+            transformer_path = self.model_config["transformer_path"]
         else:
-            transformer_path = Path(self.model_config['diffusers_path']) / 'transformer'
-        with open('configs/qwen_image/transformer/config.json') as f:
+            transformer_path = Path(self.model_config["diffusers_path"]) / "transformer"
+        with open("configs/qwen_image/transformer/config.json") as f:
             json_config = json.load(f)
 
         with init_empty_weights():
             transformer = diffusers.QwenImageTransformer2DModel.from_config(json_config)
 
         for key, tensor in iterate_safetensors(transformer_path):
-            dtype_to_use = dtype if any(keyword in key for keyword in KEEP_IN_HIGH_PRECISION) or tensor.ndim == 1 else transformer_dtype
-            set_module_tensor_to_device(transformer, key, device='cpu', dtype=dtype_to_use, value=tensor)
+            dtype_to_use = (
+                dtype
+                if any(keyword in key for keyword in KEEP_IN_HIGH_PRECISION)
+                or tensor.ndim == 1
+                else transformer_dtype
+            )
+            set_module_tensor_to_device(
+                transformer, key, device="cpu", dtype=dtype_to_use, value=tensor
+            )
 
         attn_processor = QwenDoubleStreamAttnProcessor2_0()
         for block in transformer.transformer_blocks:
@@ -284,11 +326,19 @@ class QwenImagePipeline(BasePipeline):
     def save_adapter(self, save_dir, peft_state_dict):
         self.peft_config.save_pretrained(save_dir)
         # ComfyUI format.
-        peft_state_dict = {'diffusion_model.'+k: v for k, v in peft_state_dict.items()}
-        safetensors.torch.save_file(peft_state_dict, save_dir / 'adapter_model.safetensors', metadata={'format': 'pt'})
+        peft_state_dict = {
+            "diffusion_model." + k: v for k, v in peft_state_dict.items()
+        }
+        safetensors.torch.save_file(
+            peft_state_dict,
+            save_dir / "adapter_model.safetensors",
+            metadata={"format": "pt"},
+        )
 
     def save_model(self, save_dir, state_dict):
-        safetensors.torch.save_file(state_dict, save_dir / 'model.safetensors', metadata={'format': 'pt'})
+        safetensors.torch.save_file(
+            state_dict, save_dir / "model.safetensors", metadata={"format": "pt"}
+        )
 
     def get_preprocess_media_file_fn(self):
         return self.preprocess_media_file_fn
@@ -298,37 +348,42 @@ class QwenImagePipeline(BasePipeline):
             image = args[0]
             latents = vae.encode(image.to(vae.device, vae.dtype)).latent_dist.mode()
             latents = (latents - vae.latents_mean_tensor) / vae.latents_std_tensor
-            result = {'latents': latents}
+            result = {"latents": latents}
             if len(args) == 2:
                 control_image = args[1]
-                control_latents = vae.encode(control_image.to(vae.device, vae.dtype)).latent_dist.mode()
-                control_latents = (control_latents - vae.latents_mean_tensor) / vae.latents_std_tensor
-                result['control_latents'] = control_latents
+                control_latents = vae.encode(
+                    control_image.to(vae.device, vae.dtype)
+                ).latent_dist.mode()
+                control_latents = (
+                    control_latents - vae.latents_mean_tensor
+                ) / vae.latents_std_tensor
+                result["control_latents"] = control_latents
             return result
+
         return fn
 
     def load_image_for_vlm(self, path):
         pil_img = Image.open(path)
         height, width = pil_img.height, pil_img.width
 
-        if pil_img.mode not in ['RGB', 'RGBA'] and 'transparency' in pil_img.info:
-            pil_img = pil_img.convert('RGBA')
+        if pil_img.mode not in ["RGB", "RGBA"] and "transparency" in pil_img.info:
+            pil_img = pil_img.convert("RGBA")
 
         # add white background for transparent images
-        if pil_img.mode == 'RGBA':
-            canvas = Image.new('RGBA', pil_img.size, (255, 255, 255))
+        if pil_img.mode == "RGBA":
+            canvas = Image.new("RGBA", pil_img.size, (255, 255, 255))
             canvas.alpha_composite(pil_img)
-            pil_img = canvas.convert('RGB')
+            pil_img = canvas.convert("RGB")
         else:
-            pil_img = pil_img.convert('RGB')
+            pil_img = pil_img.convert("RGB")
 
-        scale_factor = self.vlm_image_size / math.sqrt(height*width)
+        scale_factor = self.vlm_image_size / math.sqrt(height * width)
         return ImageOps.scale(pil_img, scale_factor)
 
     def _get_qwen_prompt_embeds(
         self,
         prompt,
-        control_files,
+        reference_files,
         device=None,
         dtype=None,
     ):
@@ -337,12 +392,16 @@ class QwenImagePipeline(BasePipeline):
 
         prompt = [prompt] if isinstance(prompt, str) else prompt
 
-        if control_files is None:
+        if reference_files is None:
             template = self.prompt_template_encode
             drop_idx = self.prompt_template_encode_start_idx
             txt = [template.format(e) for e in prompt]
             txt_tokens = self.tokenizer(
-                txt, max_length=self.tokenizer_max_length + drop_idx, padding=True, truncation=True, return_tensors="pt"
+                txt,
+                max_length=self.tokenizer_max_length + drop_idx,
+                padding=True,
+                truncation=True,
+                return_tensors="pt",
             ).to(device)
             attention_mask = txt_tokens.attention_mask
             outputs = self.text_encoder(
@@ -354,10 +413,7 @@ class QwenImagePipeline(BasePipeline):
             template = self.prompt_template_encode_edit
             drop_idx = self.prompt_template_encode_start_idx_edit
             txt = [template.format(e) for e in prompt]
-            images = [
-                self.load_image_for_vlm(file)
-                for file in control_files
-            ]
+            images = [self.load_image_for_vlm(file) for file in reference_files]
             model_inputs = self.processor(
                 text=txt,
                 images=images,
@@ -380,27 +436,39 @@ class QwenImagePipeline(BasePipeline):
         return split_hidden_states
 
     def get_call_text_encoder_fn(self, text_encoder):
-        def fn(caption, is_video, control_file: list[str] | None):
+        def fn(caption, is_video, reference_file: list[str] | None):
             # args are lists
             assert not any(is_video)
-            prompt_embeds = self._get_qwen_prompt_embeds(caption, control_file, device=text_encoder.device)
-            return {'prompt_embeds': prompt_embeds}
+            prompt_embeds = self._get_qwen_prompt_embeds(
+                caption, reference_file, device=text_encoder.device
+            )
+            return {"prompt_embeds": prompt_embeds}
+
         return fn
 
     def prepare_inputs(self, inputs, timestep_quantile=None):
-        latents = inputs['latents'].float()
-        prompt_embeds = inputs['prompt_embeds']
-        mask = inputs['mask']
+        latents = inputs["latents"].float()
+        prompt_embeds = inputs["prompt_embeds"]
+        mask = inputs["mask"]
         device = latents.device
 
         # prompt embeds are variable length
-        attn_mask_list = [torch.ones(e.size(0), dtype=torch.bool, device=device) for e in prompt_embeds]
+        attn_mask_list = [
+            torch.ones(e.size(0), dtype=torch.bool, device=device)
+            for e in prompt_embeds
+        ]
         max_seq_len = max([e.size(0) for e in prompt_embeds])
         prompt_embeds = torch.stack(
-            [torch.cat([u, u.new_zeros(max_seq_len - u.size(0), u.size(1))]) for u in prompt_embeds]
+            [
+                torch.cat([u, u.new_zeros(max_seq_len - u.size(0), u.size(1))])
+                for u in prompt_embeds
+            ]
         )
         prompt_embeds_mask = torch.stack(
-            [torch.cat([u, u.new_zeros(max_seq_len - u.size(0))]) for u in attn_mask_list]
+            [
+                torch.cat([u, u.new_zeros(max_seq_len - u.size(0))])
+                for u in attn_mask_list
+            ]
         )
 
         max_text_len = prompt_embeds_mask.sum(dim=1).max().item()
@@ -414,16 +482,22 @@ class QwenImagePipeline(BasePipeline):
         latents = self._pack_latents(latents, bs, num_channels_latents, h, w)
 
         if mask is not None:
-            mask = mask.unsqueeze(1).expand((-1, num_channels_latents, -1, -1))  # make mask (bs, c, img_h, img_w)
-            mask = F.interpolate(mask, size=(h, w), mode='nearest-exact')  # resize to latent spatial dimension
+            mask = mask.unsqueeze(1).expand(
+                (-1, num_channels_latents, -1, -1)
+            )  # make mask (bs, c, img_h, img_w)
+            mask = F.interpolate(
+                mask, size=(h, w), mode="nearest-exact"
+            )  # resize to latent spatial dimension
             mask = mask.unsqueeze(2)  # add frame dimension
             mask = self._pack_latents(mask, bs, num_channels_latents, h, w)
 
-        timestep_sample_method = self.model_config.get('timestep_sample_method', 'logit_normal')
+        timestep_sample_method = self.model_config.get(
+            "timestep_sample_method", "logit_normal"
+        )
 
-        if timestep_sample_method == 'logit_normal':
+        if timestep_sample_method == "logit_normal":
             dist = torch.distributions.normal.Normal(0, 1)
-        elif timestep_sample_method == 'uniform':
+        elif timestep_sample_method == "uniform":
             dist = torch.distributions.uniform.Uniform(0, 1)
         else:
             raise NotImplementedError()
@@ -433,14 +507,14 @@ class QwenImagePipeline(BasePipeline):
         else:
             t = dist.sample((bs,)).to(device)
 
-        if timestep_sample_method == 'logit_normal':
-            sigmoid_scale = self.model_config.get('sigmoid_scale', 1.0)
+        if timestep_sample_method == "logit_normal":
+            sigmoid_scale = self.model_config.get("sigmoid_scale", 1.0)
             t = t * sigmoid_scale
             t = torch.sigmoid(t)
 
-        if shift := self.model_config.get('shift', None):
+        if shift := self.model_config.get("shift", None):
             t = (t * shift) / (1 + (shift - 1) * t)
-        elif self.model_config.get('flux_shift', False):
+        elif self.model_config.get("flux_shift", False):
             mu = get_lin_function(y1=0.5, y2=1.15)((h // 2) * (w // 2))
             t = time_shift(mu, 1.0, t)
 
@@ -452,10 +526,15 @@ class QwenImagePipeline(BasePipeline):
 
         img_shapes = [(1, h // 2, w // 2)]
 
-        if 'control_latents' in inputs:
-            control_latents = inputs['control_latents'].float()
-            control_latents = self._pack_latents(control_latents, bs, num_channels_latents, h, w)
-            assert control_latents.shape == latents.shape, (control_latents.shape, latents.shape)
+        if "control_latents" in inputs:
+            control_latents = inputs["control_latents"].float()
+            control_latents = self._pack_latents(
+                control_latents, bs, num_channels_latents, h, w
+            )
+            assert control_latents.shape == latents.shape, (
+                control_latents.shape,
+                latents.shape,
+            )
             img_seq_len = torch.tensor(x_t.shape[1], device=x_t.device).repeat((bs,))
             extra = (img_seq_len,)
             x_t = torch.cat([x_t, control_latents], dim=1)
@@ -463,9 +542,15 @@ class QwenImagePipeline(BasePipeline):
         else:
             extra = tuple()
 
-        img_shapes = torch.tensor([img_shapes], dtype=torch.int32, device=device).repeat((bs, 1, 1))
-        txt_seq_lens = torch.tensor([max_text_len], dtype=torch.int32, device=device).repeat((bs,))
-        img_attention_mask = torch.ones((bs, x_t.shape[1]), dtype=torch.bool, device=device)
+        img_shapes = torch.tensor(
+            [img_shapes], dtype=torch.int32, device=device
+        ).repeat((bs, 1, 1))
+        txt_seq_lens = torch.tensor(
+            [max_text_len], dtype=torch.int32, device=device
+        ).repeat((bs,))
+        img_attention_mask = torch.ones(
+            (bs, x_t.shape[1]), dtype=torch.bool, device=device
+        )
         attention_mask = torch.cat([prompt_embeds_mask, img_attention_mask], dim=1)
         # Make broadcastable with attention weights, which are [bs, num_heads, query_len, key_value_len]
         attention_mask = attention_mask.view(bs, 1, 1, -1)
@@ -490,15 +575,23 @@ class QwenImagePipeline(BasePipeline):
         num_blocks = len(blocks)
         assert (
             blocks_to_swap <= num_blocks - 2
-        ), f'Cannot swap more than {num_blocks - 2} blocks. Requested {blocks_to_swap} blocks to swap.'
+        ), f"Cannot swap more than {num_blocks - 2} blocks. Requested {blocks_to_swap} blocks to swap."
         self.offloader = ModelOffloader(
-            'TransformerBlock', blocks, num_blocks, blocks_to_swap, True, torch.device('cuda'), self.config['reentrant_activation_checkpointing']
+            "TransformerBlock",
+            blocks,
+            num_blocks,
+            blocks_to_swap,
+            True,
+            torch.device("cuda"),
+            self.config["reentrant_activation_checkpointing"],
         )
         transformer.transformer_blocks = None
-        transformer.to('cuda')
+        transformer.to("cuda")
         transformer.transformer_blocks = blocks
         self.prepare_block_swap_training()
-        print(f'Block swap enabled. Swapping {blocks_to_swap} blocks out of {num_blocks} blocks.')
+        print(
+            f"Block swap enabled. Swapping {blocks_to_swap} blocks out of {num_blocks} blocks."
+        )
 
     def prepare_block_swap_training(self):
         self.offloader.enable_block_swap()
@@ -521,13 +614,21 @@ class InitialLayer(nn.Module):
         self.time_text_embed = model.time_text_embed
         self.pos_embed = model.pos_embed
 
-    @torch.autocast('cuda', dtype=AUTOCAST_DTYPE)
+    @torch.autocast("cuda", dtype=AUTOCAST_DTYPE)
     def forward(self, inputs):
         for item in inputs:
             if torch.is_floating_point(item):
                 item.requires_grad_(True)
 
-        hidden_states, encoder_hidden_states, attention_mask, timestep, img_shapes, txt_seq_lens, *extra = inputs
+        (
+            hidden_states,
+            encoder_hidden_states,
+            attention_mask,
+            timestep,
+            img_shapes,
+            txt_seq_lens,
+            *extra,
+        ) = inputs
 
         hidden_states = self.img_in(hidden_states)
 
@@ -539,9 +640,18 @@ class InitialLayer(nn.Module):
 
         img_shapes = img_shapes.tolist()
         txt_seq_lens = txt_seq_lens.tolist()
-        vid_freqs, txt_freqs = self.pos_embed(img_shapes, txt_seq_lens, device=hidden_states.device)
+        vid_freqs, txt_freqs = self.pos_embed(
+            img_shapes, txt_seq_lens, device=hidden_states.device
+        )
 
-        return make_contiguous(hidden_states, encoder_hidden_states, attention_mask, temb, vid_freqs, txt_freqs) + tuple(extra)
+        return make_contiguous(
+            hidden_states,
+            encoder_hidden_states,
+            attention_mask,
+            temb,
+            vid_freqs,
+            txt_freqs,
+        ) + tuple(extra)
 
     def rope_params(self, index, dim, theta=10000):
         """
@@ -549,7 +659,14 @@ class InitialLayer(nn.Module):
             index: [0, 1, 2, 3] 1D Tensor representing the position index of the token
         """
         assert dim % 2 == 0
-        freqs = torch.outer(index, 1.0 / torch.pow(theta, torch.arange(0, dim, 2, device=index.device).to(torch.float32).div(dim)))
+        freqs = torch.outer(
+            index,
+            1.0
+            / torch.pow(
+                theta,
+                torch.arange(0, dim, 2, device=index.device).to(torch.float32).div(dim),
+            ),
+        )
         freqs = torch.polar(torch.ones_like(freqs), freqs)
         return freqs
 
@@ -561,9 +678,17 @@ class TransformerLayer(nn.Module):
         self.block_idx = block_idx
         self.offloader = offloader
 
-    @torch.autocast('cuda', dtype=AUTOCAST_DTYPE)
+    @torch.autocast("cuda", dtype=AUTOCAST_DTYPE)
     def forward(self, inputs):
-        hidden_states, encoder_hidden_states, attention_mask, temb, vid_freqs, txt_freqs, *extra = inputs
+        (
+            hidden_states,
+            encoder_hidden_states,
+            attention_mask,
+            temb,
+            vid_freqs,
+            txt_freqs,
+            *extra,
+        ) = inputs
 
         self.offloader.wait_for_block(self.block_idx)
         encoder_hidden_states, hidden_states = self.block(
@@ -572,11 +697,18 @@ class TransformerLayer(nn.Module):
             encoder_hidden_states_mask=None,
             temb=temb,
             image_rotary_emb=(vid_freqs, txt_freqs),
-            joint_attention_kwargs={'attention_mask': attention_mask},
+            joint_attention_kwargs={"attention_mask": attention_mask},
         )
         self.offloader.submit_move_blocks_forward(self.block_idx)
 
-        return make_contiguous(hidden_states, encoder_hidden_states, attention_mask, temb, vid_freqs, txt_freqs) + tuple(extra)
+        return make_contiguous(
+            hidden_states,
+            encoder_hidden_states,
+            attention_mask,
+            temb,
+            vid_freqs,
+            txt_freqs,
+        ) + tuple(extra)
 
 
 class FinalLayer(nn.Module):
@@ -589,9 +721,17 @@ class FinalLayer(nn.Module):
     def __getattr__(self, name):
         return getattr(self.model[0], name)
 
-    @torch.autocast('cuda', dtype=AUTOCAST_DTYPE)
+    @torch.autocast("cuda", dtype=AUTOCAST_DTYPE)
     def forward(self, inputs):
-        hidden_states, encoder_hidden_states, attention_mask, temb, vid_freqs, txt_freqs, *extra = inputs
+        (
+            hidden_states,
+            encoder_hidden_states,
+            attention_mask,
+            temb,
+            vid_freqs,
+            txt_freqs,
+            *extra,
+        ) = inputs
         hidden_states = self.norm_out(hidden_states, temb)
         output = self.proj_out(hidden_states)
         if len(extra) > 0:

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -27,7 +27,7 @@ from utils.common import is_main_process, VIDEO_EXTENSIONS, round_to_nearest_mul
 DEBUG = False
 IMAGE_SIZE_ROUND_TO_MULTIPLE = 32
 NUM_PROC = min(8, os.cpu_count())
-CAPTIONS_JSON_FILE = 'captions.json'
+CAPTIONS_JSON_FILE = "captions.json"
 ROUND_DECIMAL_DIGITS = 3
 
 UNCOND_FRACTION = 0.0
@@ -40,7 +40,9 @@ def shuffle_with_seed(l, seed=None):
     random.setstate(rng_state)
 
 
-def shuffle_captions(captions: list[str], count: int = 0, delimiter: str = ', ', caption_prefix: str = '') -> list[str]:
+def shuffle_captions(
+    captions: list[str], count: int = 0, delimiter: str = ", ", caption_prefix: str = ""
+) -> list[str]:
     if count == 0:
         return [caption_prefix + c for c in captions]
 
@@ -49,21 +51,25 @@ def shuffle_captions(captions: list[str], count: int = 0, delimiter: str = ', ',
         random.shuffle(split)
         return delimiter.join(split)
 
-    return [caption_prefix + shuffle_caption(caption, delimiter) for caption in captions for _ in range(count)]
+    return [
+        caption_prefix + shuffle_caption(caption, delimiter)
+        for caption in captions
+        for _ in range(count)
+    ]
 
 
 def bucket_suffix(key):
     if len(key) == 2:
         # AR, frames
-        return f'{key[0]:.{ROUND_DECIMAL_DIGITS}f}_{key[1]}'
+        return f"{key[0]:.{ROUND_DECIMAL_DIGITS}f}_{key[1]}"
     elif len(key) == 3:
         # width, height, frames
-        return f'{key[0]}x{key[1]}x{key[2]}'
+        return f"{key[0]}x{key[1]}x{key[2]}"
     elif len(key) == 4:
         # AR, width, height, frames
-        return f'{key[0]:.{ROUND_DECIMAL_DIGITS}f}x{key[1]}x{key[2]}x{key[3]}'
+        return f"{key[0]:.{ROUND_DECIMAL_DIGITS}f}x{key[1]}x{key[2]}x{key[3]}"
     else:
-        raise RuntimeError(f'Unexpected bucket: {key}')
+        raise RuntimeError(f"Unexpected bucket: {key}")
 
 
 def dedup_and_sort(values):
@@ -73,7 +79,15 @@ def dedup_and_sort(values):
     return np.array(values)
 
 
-def _map_and_cache(dataset, map_fn, cache_dir, cache_file_prefix='', new_fingerprint_args=None, regenerate_cache=False, caching_batch_size=1):
+def _map_and_cache(
+    dataset,
+    map_fn,
+    cache_dir,
+    cache_file_prefix="",
+    new_fingerprint_args=None,
+    regenerate_cache=False,
+    caching_batch_size=1,
+):
     # TODO: remove. Currently using this to avoid recaching everything.
     # cache_arrow_files = list(str(path) for path in cache_dir.glob(f'{cache_file_prefix}*.arrow'))
     # cache_arrow_files.sort()
@@ -96,7 +110,7 @@ def _map_and_cache(dataset, map_fn, cache_dir, cache_file_prefix='', new_fingerp
     new_fingerprint_args = [] if new_fingerprint_args is None else new_fingerprint_args
     new_fingerprint_args.append(dataset._fingerprint)
     new_fingerprint = Hasher.hash(new_fingerprint_args)
-    cache_file = cache_dir / f'{cache_file_prefix}{new_fingerprint}.arrow'
+    cache_file = cache_dir / f"{cache_file_prefix}{new_fingerprint}.arrow"
     cache_file = str(cache_file)
     dataset = dataset.map(
         map_fn,
@@ -110,7 +124,7 @@ def _map_and_cache(dataset, map_fn, cache_dir, cache_file_prefix='', new_fingerp
         num_proc=NUM_PROC,
         with_rank=True,
     )
-    dataset.set_format('torch')
+    dataset.set_format("torch")
     return dataset
 
 
@@ -120,32 +134,39 @@ class TextEmbeddingDataset:
         self.image_spec_to_te_idx = defaultdict(list)
         # TODO: maybe make this use Dataset object like the latents. But, you won't be caching text embeddings
         # when training on very large datasets, so perhaps it doesn't really matter.
-        for i, image_spec in enumerate(te_dataset['image_spec']):
+        for i, image_spec in enumerate(te_dataset["image_spec"]):
             self.image_spec_to_te_idx[tuple(image_spec)].append(i)
 
     def get_text_embeddings(self, image_spec, caption_number):
         return self.te_dataset[self.image_spec_to_te_idx[image_spec][caption_number]]
 
 
-def _cache_text_embeddings(metadata_dataset, map_fn, i, cache_dir, regenerate_cache, caching_batch_size):
+def _cache_text_embeddings(
+    metadata_dataset, map_fn, i, cache_dir, regenerate_cache, caching_batch_size
+):
 
     def flatten_captions(example):
         result = {key: [] for key in example}
-        for i, captions in enumerate(example['caption']):
+        for i, captions in enumerate(example["caption"]):
             for caption in captions:
-                result['caption'].append(caption)
+                result["caption"].append(caption)
                 for key, value in example.items():
-                    if key == 'caption':
+                    if key == "caption":
                         continue
                     result[key].append(value[i])
         return result
 
-    flattened_captions = metadata_dataset.map(flatten_captions, batched=True, keep_in_memory=True, remove_columns=metadata_dataset.column_names)
+    flattened_captions = metadata_dataset.map(
+        flatten_captions,
+        batched=True,
+        keep_in_memory=True,
+        remove_columns=metadata_dataset.column_names,
+    )
     te_dataset = _map_and_cache(
         flattened_captions,
         map_fn,
         cache_dir,
-        cache_file_prefix=f'text_embeddings_{i}_',
+        cache_file_prefix=f"text_embeddings_{i}_",
         new_fingerprint_args=[i],
         regenerate_cache=regenerate_cache,
         caching_batch_size=caching_batch_size,
@@ -160,47 +181,57 @@ class SizeBucketDataset:
         self.metadata_dataset = metadata_dataset
         self.directory_config = directory_config
         self.size_bucket = size_bucket
-        self.path = Path(self.directory_config['path'])
-        self.cache_dir = cache_base / f'cache_{bucket_suffix(size_bucket)}'
+        self.path = Path(self.directory_config["path"])
+        self.cache_dir = cache_base / f"cache_{bucket_suffix(size_bucket)}"
 
         if len(size_bucket) == 4:
             # rename old folder name to the new one for convenience
-            old_cache_dir = cache_base / f'cache_{bucket_suffix(size_bucket[1:])}'
+            old_cache_dir = cache_base / f"cache_{bucket_suffix(size_bucket[1:])}"
             if old_cache_dir.exists() and not self.cache_dir.exists():
                 old_cache_dir.rename(self.cache_dir)
 
         os.makedirs(self.cache_dir, exist_ok=True)
         self.text_embedding_datasets = []
         self.uncond_text_embeddings = []
-        self.num_repeats = self.directory_config['num_repeats']
-        self.shuffle_skip = max(directory_config.get('cache_shuffle_num', 0), 1) # Should be provided in DirectoryDataset
+        self.num_repeats = self.directory_config["num_repeats"]
+        self.shuffle_skip = max(
+            directory_config.get("cache_shuffle_num", 0), 1
+        )  # Should be provided in DirectoryDataset
         if self.num_repeats <= 0:
-            raise ValueError(f'num_repeats must be >0, was {self.num_repeats}')
+            raise ValueError(f"num_repeats must be >0, was {self.num_repeats}")
 
-    def cache_latents(self, map_fn, regenerate_cache=False, trust_cache=False, caching_batch_size=1):
-        print(f'caching latents: {self.size_bucket}')
+    def cache_latents(
+        self, map_fn, regenerate_cache=False, trust_cache=False, caching_batch_size=1
+    ):
+        print(f"caching latents: {self.size_bucket}")
         self.latent_dataset = _map_and_cache(
             self.metadata_dataset,
             map_fn,
             self.cache_dir,
-            cache_file_prefix='latents_',
+            cache_file_prefix="latents_",
             regenerate_cache=regenerate_cache,
             caching_batch_size=caching_batch_size,
         )
 
-        iteration_order_cache_dir = self.cache_dir / 'iteration_order'
+        iteration_order_cache_dir = self.cache_dir / "iteration_order"
 
-        if regenerate_cache or not iteration_order_cache_dir.exists() or not trust_cache:
-            print('Building iteration order')
+        if (
+            regenerate_cache
+            or not iteration_order_cache_dir.exists()
+            or not trust_cache
+        ):
+            print("Building iteration order")
             image_spec_to_latents_idx = {
                 tuple(image_spec): i
-                for i, image_spec in enumerate(self.latent_dataset['image_spec'])
+                for i, image_spec in enumerate(self.latent_dataset["image_spec"])
             }
 
             iteration_order_list = []
-            for example in self.metadata_dataset.select_columns(['image_spec', 'caption']):
-                image_spec = example['image_spec']
-                captions = example['caption']
+            for example in self.metadata_dataset.select_columns(
+                ["image_spec", "caption"]
+            ):
+                image_spec = example["image_spec"]
+                captions = example["caption"]
                 latents_idx = image_spec_to_latents_idx[tuple(image_spec)]
                 for i, caption in enumerate(captions):
                     iteration_order_list.append((image_spec, latents_idx, caption, i))
@@ -211,18 +242,39 @@ class SizeBucketDataset:
             shuffle_with_seed(iteration_order_list, 42)
 
             def iteration_order_gen():
-                for image_spec, latents_idx, caption, caption_number in iteration_order_list:
-                    yield {'image_spec': image_spec, 'latents_idx': latents_idx, 'caption': caption, 'caption_number': caption_number}
+                for (
+                    image_spec,
+                    latents_idx,
+                    caption,
+                    caption_number,
+                ) in iteration_order_list:
+                    yield {
+                        "image_spec": image_spec,
+                        "latents_idx": latents_idx,
+                        "caption": caption,
+                        "caption_number": caption_number,
+                    }
 
-            iteration_order = datasets.Dataset.from_generator(iteration_order_gen, keep_in_memory=True)
+            iteration_order = datasets.Dataset.from_generator(
+                iteration_order_gen, keep_in_memory=True
+            )
             iteration_order.save_to_disk(str(iteration_order_cache_dir))
             del iteration_order
 
         self.iteration_order = datasets.load_from_disk(str(iteration_order_cache_dir))
 
-    def cache_text_embeddings(self, map_fn, i, regenerate_cache=False, caching_batch_size=1):
-        print(f'caching text embeddings: {self.size_bucket}')
-        te_dataset = _cache_text_embeddings(self.metadata_dataset, map_fn, i, self.cache_dir, regenerate_cache, caching_batch_size)
+    def cache_text_embeddings(
+        self, map_fn, i, regenerate_cache=False, caching_batch_size=1
+    ):
+        print(f"caching text embeddings: {self.size_bucket}")
+        te_dataset = _cache_text_embeddings(
+            self.metadata_dataset,
+            map_fn,
+            i,
+            self.cache_dir,
+            regenerate_cache,
+            caching_batch_size,
+        )
         self.text_embedding_datasets.append(te_dataset)
 
     def add_text_embedding_dataset(self, te_dataset):
@@ -232,15 +284,23 @@ class SizeBucketDataset:
         idx = idx % len(self.iteration_order)
         entry = self.iteration_order[idx]
 
-        ret = self.latent_dataset[entry['latents_idx']]
+        ret = self.latent_dataset[entry["latents_idx"]]
 
         use_uncond = UNCOND_FRACTION > 0 and random.random() < UNCOND_FRACTION
-        caption = '' if use_uncond else entry['caption']
+        caption = "" if use_uncond else entry["caption"]
 
-        for ds, uncond_ds in zip(self.text_embedding_datasets, self.uncond_text_embeddings):
-            emb_dict = uncond_ds[0] if use_uncond else ds.get_text_embeddings(tuple(entry['image_spec']), entry['caption_number'])
+        for ds, uncond_ds in zip(
+            self.text_embedding_datasets, self.uncond_text_embeddings
+        ):
+            emb_dict = (
+                uncond_ds[0]
+                if use_uncond
+                else ds.get_text_embeddings(
+                    tuple(entry["image_spec"]), entry["caption_number"]
+                )
+            )
             ret.update(emb_dict)
-        ret['caption'] = caption
+        ret["caption"] = caption
         return ret
 
     def __len__(self):
@@ -259,7 +319,7 @@ class ConcatenatedBatchedDataset:
         size_bucket = self.datasets[0].size_bucket
         for i, ds in enumerate(self.datasets):
             assert ds.size_bucket == size_bucket
-            iteration_order.extend([i]*len(ds))
+            iteration_order.extend([i] * len(ds))
         shuffle_with_seed(iteration_order, 0)
         cumulative_sums = [0] * len(self.datasets)
         for k, dataset_idx in enumerate(iteration_order):
@@ -278,32 +338,41 @@ class ConcatenatedBatchedDataset:
         assert self.post_init_called
         start = idx * self.batch_size
         end = start + self.batch_size
-        return [self.datasets[i.item()][j.item()] for i, j in self.iteration_order[start:end]]
+        return [
+            self.datasets[i.item()][j.item()]
+            for i, j in self.iteration_order[start:end]
+        ]
 
     def _make_divisible_by(self, n):
         new_length = (len(self.iteration_order) // n) * n
         self.iteration_order = self.iteration_order[:new_length]
         if new_length == 0 and is_main_process():
-            logger.warning(f"size bucket {self.datasets[0].size_bucket} is being completely dropped because it doesn't have enough images")
+            logger.warning(
+                f"size bucket {self.datasets[0].size_bucket} is being completely dropped because it doesn't have enough images"
+            )
 
 
 class ARBucketDataset:
-    def __init__(self, ar_frames, resolutions, metadata_dataset, directory_config, cache_base):
+    def __init__(
+        self, ar_frames, resolutions, metadata_dataset, directory_config, cache_base
+    ):
         self.ar_frames = ar_frames
         self.resolutions = resolutions
         self.metadata_dataset = metadata_dataset
         self.directory_config = directory_config
         self.size_buckets = []
-        self.path = Path(directory_config['path'])
+        self.path = Path(directory_config["path"])
         self.cache_base = cache_base
-        self.cache_dir = cache_base / f'ar_frames_{bucket_suffix(self.ar_frames)}'
+        self.cache_dir = cache_base / f"ar_frames_{bucket_suffix(self.ar_frames)}"
         os.makedirs(self.cache_dir, exist_ok=True)
 
     def get_size_bucket_datasets(self):
         return self.size_buckets
 
-    def cache_latents(self, map_fn, regenerate_cache=False, trust_cache=False, caching_batch_size=1):
-        print(f'caching latents: {self.ar_frames}')
+    def cache_latents(
+        self, map_fn, regenerate_cache=False, trust_cache=False, caching_batch_size=1
+    ):
+        print(f"caching latents: {self.ar_frames}")
 
         for res in self.resolutions:
             area = res**2
@@ -315,27 +384,56 @@ class ARBucketDataset:
             # to make sure the directory has a unique name
             naming_size_bucket = (self.ar_frames[0],) + size_bucket
             metadata_with_size_bucket = self.metadata_dataset.map(
-                lambda example: {'size_bucket': size_bucket},
-                cache_file_name=str(self.cache_dir / f'metadata/metadata_{bucket_suffix(naming_size_bucket)}.arrow'),
+                lambda example: {"size_bucket": size_bucket},
+                cache_file_name=str(
+                    self.cache_dir
+                    / f"metadata/metadata_{bucket_suffix(naming_size_bucket)}.arrow"
+                ),
                 load_from_cache_file=(not regenerate_cache and trust_cache),
-                desc='Adding size bucket',
+                desc="Adding size bucket",
             )
             self.size_buckets.append(
-                SizeBucketDataset(metadata_with_size_bucket, self.directory_config, naming_size_bucket, self.cache_base)
+                SizeBucketDataset(
+                    metadata_with_size_bucket,
+                    self.directory_config,
+                    naming_size_bucket,
+                    self.cache_base,
+                )
             )
 
         for ds in self.size_buckets:
-            ds.cache_latents(map_fn, regenerate_cache=regenerate_cache, trust_cache=trust_cache, caching_batch_size=caching_batch_size)
+            ds.cache_latents(
+                map_fn,
+                regenerate_cache=regenerate_cache,
+                trust_cache=trust_cache,
+                caching_batch_size=caching_batch_size,
+            )
 
-    def cache_text_embeddings(self, map_fn, i, regenerate_cache=False, caching_batch_size=1):
-        print(f'caching text embeddings: {self.ar_frames}')
-        te_dataset = _cache_text_embeddings(self.metadata_dataset, map_fn, i, self.cache_dir, regenerate_cache, caching_batch_size)
+    def cache_text_embeddings(
+        self, map_fn, i, regenerate_cache=False, caching_batch_size=1
+    ):
+        print(f"caching text embeddings: {self.ar_frames}")
+        te_dataset = _cache_text_embeddings(
+            self.metadata_dataset,
+            map_fn,
+            i,
+            self.cache_dir,
+            regenerate_cache,
+            caching_batch_size,
+        )
         for size_bucket_dataset in self.size_buckets:
             size_bucket_dataset.add_text_embedding_dataset(te_dataset)
 
 
 class DirectoryDataset:
-    def __init__(self, directory_config, dataset_config, model_name, framerate=None, skip_dataset_validation=False):
+    def __init__(
+        self,
+        directory_config,
+        dataset_config,
+        model_name,
+        framerate=None,
+        skip_dataset_validation=False,
+    ):
         self._set_defaults(directory_config, dataset_config)
         self.directory_config = directory_config
         self.dataset_config = dataset_config
@@ -343,10 +441,14 @@ class DirectoryDataset:
             self.validate()
         self.model_name = model_name
         self.framerate = framerate
-        self.enable_ar_bucket = directory_config.get('enable_ar_bucket', dataset_config.get('enable_ar_bucket', False))
+        self.enable_ar_bucket = directory_config.get(
+            "enable_ar_bucket", dataset_config.get("enable_ar_bucket", False)
+        )
         # Configure directly from user-specified size buckets.
-        self.size_buckets = directory_config.get('size_buckets', dataset_config.get('size_buckets', None))
-        self.use_size_buckets = (self.size_buckets is not None)
+        self.size_buckets = directory_config.get(
+            "size_buckets", dataset_config.get("size_buckets", None)
+        )
+        self.use_size_buckets = self.size_buckets is not None
         if self.use_size_buckets:
             # sort size bucket from longest frame length to shortest
             self.size_buckets.sort(key=lambda t: t[-1], reverse=True)
@@ -354,44 +456,91 @@ class DirectoryDataset:
             self.size_bucket_datasets = []
         else:
             self.resolutions = self._process_user_provided_resolutions(
-                directory_config.get('resolutions', dataset_config['resolutions'])
+                directory_config.get("resolutions", dataset_config["resolutions"])
             )
             self.resolutions = dedup_and_sort(self.resolutions)
             self.ar_bucket_datasets = []
-        self.shuffle = directory_config.get('cache_shuffle_num', dataset_config.get('cache_shuffle_num', 0))
-        self.directory_config['cache_shuffle_num'] = self.shuffle # Make accessible if it wasn't yet, for picking one out
-        self.shuffle_delimiter = directory_config.get('cache_shuffle_delimiter', dataset_config.get('cache_shuffle_delimiter', ", "))
-        self.path = Path(self.directory_config['path'])
-        self.mask_path = Path(self.directory_config['mask_path']) if 'mask_path' in self.directory_config else None
-        self.control_path = Path(self.directory_config['control_path']) if 'control_path' in self.directory_config else None
+        self.shuffle = directory_config.get(
+            "cache_shuffle_num", dataset_config.get("cache_shuffle_num", 0)
+        )
+        self.directory_config["cache_shuffle_num"] = (
+            self.shuffle
+        )  # Make accessible if it wasn't yet, for picking one out
+        self.shuffle_delimiter = directory_config.get(
+            "cache_shuffle_delimiter",
+            dataset_config.get("cache_shuffle_delimiter", ", "),
+        )
+        self.path = Path(self.directory_config["path"])
+        self.mask_path = (
+            Path(self.directory_config["mask_path"])
+            if "mask_path" in self.directory_config
+            else None
+        )
+        # Backwards compatibility: "control_path" previously pointed to a single
+        # directory used for both source images (UNet conditioning) and reference
+        # images (passed to the text encoder).  New configs may specify
+        # "source_path" and "reference_path" separately.  If only the legacy
+        # "control_path" is provided, use it for both.
+        self.source_path = None
+        self.reference_path = None
+        if "source_path" in self.directory_config:
+            self.source_path = Path(self.directory_config["source_path"])
+        if "reference_path" in self.directory_config:
+            self.reference_path = Path(self.directory_config["reference_path"])
+        if "control_path" in self.directory_config:
+            legacy = Path(self.directory_config["control_path"])
+            if self.source_path is None:
+                self.source_path = legacy
+            if self.reference_path is None:
+                self.reference_path = legacy
         # For testing. Default if a mask is missing.
-        self.default_mask_file = Path(self.directory_config['default_mask_file']) if 'default_mask_file' in self.directory_config else None
-        self.cache_dir = self.path / 'cache' / self.model_name
-        self.grouping_keys_json_file = self.cache_dir / 'metadata/grouping_keys.json'
+        self.default_mask_file = (
+            Path(self.directory_config["default_mask_file"])
+            if "default_mask_file" in self.directory_config
+            else None
+        )
+        self.cache_dir = self.path / "cache" / self.model_name
+        self.grouping_keys_json_file = self.cache_dir / "metadata/grouping_keys.json"
 
         if not self.path.exists() or not self.path.is_dir():
-            raise RuntimeError(f'Invalid path: {self.path}')
-        if self.mask_path is not None and (not self.mask_path.exists() or not self.mask_path.is_dir()):
-            raise RuntimeError(f'Invalid mask_path: {self.mask_path}')
-        if self.control_path is not None and (not self.control_path.exists() or not self.control_path.is_dir()):
-            raise RuntimeError(f'Invalid control_path: {self.control_path}')
-        if self.default_mask_file is not None and (not self.default_mask_file.exists() or not self.default_mask_file.is_file()):
-            raise RuntimeError(f'Invalid default_mask_file: {self.default_mask_file}')
+            raise RuntimeError(f"Invalid path: {self.path}")
+        if self.mask_path is not None and (
+            not self.mask_path.exists() or not self.mask_path.is_dir()
+        ):
+            raise RuntimeError(f"Invalid mask_path: {self.mask_path}")
+        if self.source_path is not None and (
+            not self.source_path.exists() or not self.source_path.is_dir()
+        ):
+            raise RuntimeError(f"Invalid source_path: {self.source_path}")
+        if self.reference_path is not None and (
+            not self.reference_path.exists() or not self.reference_path.is_dir()
+        ):
+            raise RuntimeError(f"Invalid reference_path: {self.reference_path}")
+        if self.default_mask_file is not None and (
+            not self.default_mask_file.exists() or not self.default_mask_file.is_file()
+        ):
+            raise RuntimeError(f"Invalid default_mask_file: {self.default_mask_file}")
 
         if self.use_size_buckets:
             self.ars = np.array([w / h for w, h, _ in self.size_buckets])
         elif not self.enable_ar_bucket:
             self.ars = np.array([1.0])
-        elif ars := self.directory_config.get('ar_buckets', self.dataset_config.get('ar_buckets', None)):
+        elif ars := self.directory_config.get(
+            "ar_buckets", self.dataset_config.get("ar_buckets", None)
+        ):
             self.ars = self._process_user_provided_ars(ars)
         else:
-            min_ar = self.directory_config.get('min_ar', self.dataset_config['min_ar'])
-            max_ar = self.directory_config.get('max_ar', self.dataset_config['max_ar'])
-            num_ar_buckets = self.directory_config.get('num_ar_buckets', self.dataset_config['num_ar_buckets'])
+            min_ar = self.directory_config.get("min_ar", self.dataset_config["min_ar"])
+            max_ar = self.directory_config.get("max_ar", self.dataset_config["max_ar"])
+            num_ar_buckets = self.directory_config.get(
+                "num_ar_buckets", self.dataset_config["num_ar_buckets"]
+            )
             self.ars = np.geomspace(min_ar, max_ar, num=num_ar_buckets)
         self.ars = dedup_and_sort(self.ars)
         self.log_ars = np.log(self.ars)
-        frame_buckets = self.directory_config.get('frame_buckets', self.dataset_config.get('frame_buckets', [1]))
+        frame_buckets = self.directory_config.get(
+            "frame_buckets", self.dataset_config.get("frame_buckets", [1])
+        )
         if 1 not in frame_buckets:
             # always have an image bucket for convenience
             frame_buckets.append(1)
@@ -399,12 +548,16 @@ class DirectoryDataset:
         self.frame_buckets = np.array(frame_buckets)
 
     def validate(self):
-        resolutions = self.directory_config.get('resolutions', self.dataset_config.get('resolutions', []))
+        resolutions = self.directory_config.get(
+            "resolutions", self.dataset_config.get("resolutions", [])
+        )
         if len(resolutions) > 3:
             if is_main_process():
-                print('WARNING: You have set a lot of resolutions in the dataset config. Please read the comments in the example dataset.toml file,'
-                      ' and make sure you understand what this setting does. If you still want to proceed with the current configuration,'
-                      ' run the script with the --i_know_what_i_am_doing flag.')
+                print(
+                    "WARNING: You have set a lot of resolutions in the dataset config. Please read the comments in the example dataset.toml file,"
+                    " and make sure you understand what this setting does. If you still want to proceed with the current configuration,"
+                    " run the script with the --i_know_what_i_am_doing flag."
+                )
             quit()
 
     def cache_metadata(self, regenerate_cache=False, trust_cache=False):
@@ -414,14 +567,19 @@ class DirectoryDataset:
             if self.grouping_keys_json_file.exists():
                 with open(self.grouping_keys_json_file) as f:
                     unique_grouping_keys = json.load(f)
-                if self.use_size_buckets and not all(len(key) == 3 for key in unique_grouping_keys):
+                if self.use_size_buckets and not all(
+                    len(key) == 3 for key in unique_grouping_keys
+                ):
                     # Using size buckets but have AR keys.
                     return False, unique_grouping_keys
                 elif not all(len(key) == 2 for key in unique_grouping_keys):
                     # Using AR buckets but have size bucket keys
                     return False, unique_grouping_keys
                 all_grouped_metadata_exists = all(
-                    (self.cache_dir / f'metadata/grouped_metadata_{bucket_suffix(key)}').exists()
+                    (
+                        self.cache_dir
+                        / f"metadata/grouped_metadata_{bucket_suffix(key)}"
+                    ).exists()
                     for key in unique_grouping_keys
                 )
             return all_grouped_metadata_exists, unique_grouping_keys
@@ -430,14 +588,21 @@ class DirectoryDataset:
         all_grouped_metadata_exists, unique_grouping_keys = check_grouped_metadata()
         if regenerate_cache or not all_grouped_metadata_exists or not trust_cache:
             # Otherwise, need to compute the ungrouped metadata and then group.
-            print('Grouped metadata is not cached. Computing ungrouped metadata and then grouping.')
-            unique_grouping_keys = self._group_metadata_and_save_to_disk(regenerate_cache=regenerate_cache, trust_cache=trust_cache)
+            print(
+                "Grouped metadata is not cached. Computing ungrouped metadata and then grouping."
+            )
+            unique_grouping_keys = self._group_metadata_and_save_to_disk(
+                regenerate_cache=regenerate_cache, trust_cache=trust_cache
+            )
         else:
-            print('Found grouped metadata cache. Directly loading it.')
+            print("Found grouped metadata cache. Directly loading it.")
 
         for grouping_key in unique_grouping_keys:
-            grouped_cache_dir = self.cache_dir / f'metadata/grouped_metadata_{bucket_suffix(grouping_key)}'
-            print(f'Loading grouped metadata with grouping key {grouping_key}')
+            grouped_cache_dir = (
+                self.cache_dir
+                / f"metadata/grouped_metadata_{bucket_suffix(grouping_key)}"
+            )
+            print(f"Loading grouped metadata with grouping key {grouping_key}")
             metadata = datasets.load_from_disk(str(grouped_cache_dir))
             if self.use_size_buckets:
                 assert len(grouping_key) == 3
@@ -460,15 +625,19 @@ class DirectoryDataset:
                     )
                 )
 
-    def _group_metadata_and_save_to_disk(self, regenerate_cache=False, trust_cache=False):
-        metadata_dataset = self._get_ungrouped_metadata(regenerate_cache=regenerate_cache, trust_cache=trust_cache)
+    def _group_metadata_and_save_to_disk(
+        self, regenerate_cache=False, trust_cache=False
+    ):
+        metadata_dataset = self._get_ungrouped_metadata(
+            regenerate_cache=regenerate_cache, trust_cache=trust_cache
+        )
         grouped_metadata = defaultdict(lambda: defaultdict(list))
         unique_grouping_keys = set()
-        for example in tqdm(metadata_dataset, desc='Grouping examples'):
+        for example in tqdm(metadata_dataset, desc="Grouping examples"):
             if self.use_size_buckets:
-                grouping_key = tuple(example['size_bucket'])
+                grouping_key = tuple(example["size_bucket"])
             else:
-                grouping_key = example['ar_bucket']
+                grouping_key = example["ar_bucket"]
                 grouping_key = (grouping_key[0], int(grouping_key[1]))
             unique_grouping_keys.add(grouping_key)
             d = grouped_metadata[grouping_key]
@@ -479,36 +648,63 @@ class DirectoryDataset:
         if self.use_size_buckets:
             for size_bucket, metadata in grouped_metadata.items():
                 metadata = datasets.Dataset.from_dict(metadata)
-                grouped_cache_dir = self.cache_dir / f'metadata/grouped_metadata_{bucket_suffix(size_bucket)}'
+                grouped_cache_dir = (
+                    self.cache_dir
+                    / f"metadata/grouped_metadata_{bucket_suffix(size_bucket)}"
+                )
                 metadata.save_to_disk(str(grouped_cache_dir))
         else:
             for ar_bucket, metadata in grouped_metadata.items():
                 metadata = datasets.Dataset.from_dict(metadata)
-                grouped_cache_dir = self.cache_dir / f'metadata/grouped_metadata_{bucket_suffix(ar_bucket)}'
+                grouped_cache_dir = (
+                    self.cache_dir
+                    / f"metadata/grouped_metadata_{bucket_suffix(ar_bucket)}"
+                )
                 metadata.save_to_disk(str(grouped_cache_dir))
 
-        with open(self.grouping_keys_json_file, 'w') as f:
+        with open(self.grouping_keys_json_file, "w") as f:
             json.dump(unique_grouping_keys, f)
 
         return unique_grouping_keys
 
     def _get_ungrouped_metadata(self, regenerate_cache=False, trust_cache=False):
         # This method caches some intermediate datasets so we don't have to enumerate all the files each time.
-        metadata_cache_file_1 = self.cache_dir / 'metadata/metadata_intermediate'
-        metadata_cache_file_2 = self.cache_dir / 'metadata/metadata.arrow'
+        metadata_cache_file_1 = self.cache_dir / "metadata/metadata_intermediate"
+        metadata_cache_file_2 = self.cache_dir / "metadata/metadata.arrow"
 
         if regenerate_cache or not metadata_cache_file_1.exists() or not trust_cache:
-            print('Intermediate metadata is not cached. Enumerating all files.')
-            files = list(self.path.glob('*'))
+            print("Intermediate metadata is not cached. Enumerating all files.")
+            files = list(self.path.glob("*"))
             # deterministic order
             files.sort()
 
             # Mask can have any extension, it just needs to have the same stem as the image.
-            mask_file_stems = {path.stem: path for path in self.mask_path.glob('*') if path.is_file()} if self.mask_path is not None else {}
-            control_file_stems = {path.stem: path for path in self.control_path.glob('*') if path.is_file()} if self.control_path is not None else {}
+            mask_file_stems = (
+                {path.stem: path for path in self.mask_path.glob("*") if path.is_file()}
+                if self.mask_path is not None
+                else {}
+            )
+            source_file_stems = (
+                {
+                    path.stem: path
+                    for path in self.source_path.glob("*")
+                    if path.is_file()
+                }
+                if self.source_path is not None
+                else {}
+            )
+            reference_file_stems = (
+                {
+                    path.stem: path
+                    for path in self.reference_path.glob("*")
+                    if path.is_file()
+                }
+                if self.reference_path is not None
+                else {}
+            )
 
             def process_file(file):
-                if file.suffix != '.tar':
+                if file.suffix != ".tar":
                     return [(None, str(file))]
                 with tarfile.TarFile(file) as tar_f:
                     return [(str(file), name) for name in tar_f.getnames()]
@@ -519,15 +715,22 @@ class DirectoryDataset:
             image_specs = []
             caption_files = []
             mask_files = []
-            control_files = []
+            source_files = []
+            reference_files = []
             for file in tqdm(files):
-                if not file.is_file() or file.suffix == '.txt' or file.suffix == '.npz' or file.suffix == '.json' or file.suffix == '.parquet':
+                if (
+                    not file.is_file()
+                    or file.suffix == ".txt"
+                    or file.suffix == ".npz"
+                    or file.suffix == ".json"
+                    or file.suffix == ".parquet"
+                ):
                     continue
                 for image_spec in process_file(file):
                     image_file = Path(image_spec[1])
-                    caption_file = image_file.with_suffix('.txt')
+                    caption_file = image_file.with_suffix(".txt")
                     if has_captions_json or not os.path.exists(caption_file):
-                        caption_file = ''
+                        caption_file = ""
                     image_specs.append(image_spec)
                     caption_files.append(str(caption_file))
                     # mask
@@ -537,56 +740,82 @@ class DirectoryDataset:
                         mask_files.append(str(self.default_mask_file))
                     else:
                         if self.mask_path is not None:
-                            logger.warning(f'No mask file was found for image {image_file}, not using mask.')
+                            logger.warning(
+                                f"No mask file was found for image {image_file}, not using mask."
+                            )
                         mask_files.append(None)
-                    # control (e.g. Flux Kontext)
-                    if self.control_path:
-                        if image_file.stem not in control_file_stems:
-                            raise RuntimeError(f'No control file exists for image {image_file}')
-                        control_files.append(str(control_file_stems[image_file.stem]))
-            assert len(image_specs) > 0, f'Directory {self.path} had no images/videos!'
+                    # source and reference images for edit datasets
+                    if self.source_path:
+                        if image_file.stem not in source_file_stems:
+                            raise RuntimeError(
+                                f"No source file exists for image {image_file}"
+                            )
+                        source_files.append(str(source_file_stems[image_file.stem]))
+                    if self.reference_path:
+                        if image_file.stem not in reference_file_stems:
+                            raise RuntimeError(
+                                f"No reference file exists for image {image_file}"
+                            )
+                        reference_files.append(
+                            str(reference_file_stems[image_file.stem])
+                        )
+            assert len(image_specs) > 0, f"Directory {self.path} had no images/videos!"
 
-            d = {'image_spec': image_specs, 'caption_file': caption_files, 'mask_file': mask_files}
-            if self.control_path:
-                d['control_file'] = control_files
+            d = {
+                "image_spec": image_specs,
+                "caption_file": caption_files,
+                "mask_file": mask_files,
+            }
+            if self.source_path:
+                d["source_file"] = source_files
+            if self.reference_path:
+                d["reference_file"] = reference_files
             metadata_dataset = datasets.Dataset.from_dict(d)
 
             if captions_json.exists():
-                print('Loading captions JSON')
+                print("Loading captions JSON")
                 with open(captions_json) as f:
                     caption_data = json.load(f)
 
                 def add_captions(example):
-                    captions = caption_data.get(example['image_spec'][1], None)
+                    captions = caption_data.get(example["image_spec"][1], None)
                     if captions is None:
-                        logger.warning(f'Image file {image_file} does not have an entry in captions.json')
+                        logger.warning(
+                            f"Image file {image_file} does not have an entry in captions.json"
+                        )
                     else:
-                        assert isinstance(captions, list), 'captions.json must contain lists of captions'
-                    return {'caption': captions}
+                        assert isinstance(
+                            captions, list
+                        ), "captions.json must contain lists of captions"
+                    return {"caption": captions}
 
                 metadata_dataset = metadata_dataset.map(
                     add_captions,
-                    cache_file_name=str(self.cache_dir / 'metadata/metadata_with_captions.arrow'),
+                    cache_file_name=str(
+                        self.cache_dir / "metadata/metadata_with_captions.arrow"
+                    ),
                     load_from_cache_file=(not regenerate_cache and trust_cache),
-                    desc='Adding captions',
+                    desc="Adding captions",
                 )
                 del caption_data
 
             # Shuffle the data. Use a deterministic seed, so the dataset is identical on all processes.
             # Seed is based on the hash of the directory path, so that if directories have the same set of images, they are shuffled differently.
-            seed = int(hashlib.md5(str.encode(str(self.path))).hexdigest(), 16) % int(1e9)
+            seed = int(hashlib.md5(str.encode(str(self.path))).hexdigest(), 16) % int(
+                1e9
+            )
             metadata_dataset = metadata_dataset.shuffle(seed=seed)
-            print('Saving intermediate metadata dataset.')
+            print("Saving intermediate metadata dataset.")
             metadata_dataset.save_to_disk(str(metadata_cache_file_1))
             # Need to delete and load from disk, or else the map() call below is extremely slow to launch worker processes
             # and they use huge amounts of memory. Probably because this dataset is in memory?
             del metadata_dataset
 
-        print('Loading intermediate metadata dataset.')
+        print("Loading intermediate metadata dataset.")
         metadata_dataset = datasets.load_from_disk(str(metadata_cache_file_1))
 
         metadata_map_fn = self._metadata_map_fn()
-        print('Caching ungrouped metadata.')
+        print("Caching ungrouped metadata.")
         metadata_dataset = metadata_dataset.map(
             metadata_map_fn,
             cache_file_name=str(metadata_cache_file_2),
@@ -599,50 +828,76 @@ class DirectoryDataset:
         return metadata_dataset
 
     def _set_defaults(self, directory_config, dataset_config):
-        directory_config.setdefault('enable_ar_bucket', dataset_config.get('enable_ar_bucket', False))
-        directory_config.setdefault('shuffle_tags', dataset_config.get('shuffle_tags', False))
-        directory_config.setdefault('caption_prefix', dataset_config.get('caption_prefix', ''))
-        directory_config.setdefault('num_repeats', dataset_config.get('num_repeats', 1))
+        directory_config.setdefault(
+            "enable_ar_bucket", dataset_config.get("enable_ar_bucket", False)
+        )
+        directory_config.setdefault(
+            "shuffle_tags", dataset_config.get("shuffle_tags", False)
+        )
+        directory_config.setdefault(
+            "caption_prefix", dataset_config.get("caption_prefix", "")
+        )
+        directory_config.setdefault("num_repeats", dataset_config.get("num_repeats", 1))
 
     def _metadata_map_fn(self):
         tarfile_map = {}
 
         def fn(example):
             # batch size always 1
-            caption_file = example['caption_file'][0]
-            image_spec = example['image_spec'][0]
+            caption_file = example["caption_file"][0]
+            image_spec = example["image_spec"][0]
             image_file = Path(image_spec[1])
             captions = None
-            if 'caption' in example:
+            if "caption" in example:
                 # Already put in dataset from captions.json file.
-                captions = example['caption'][0]
+                captions = example["caption"][0]
             if captions is None and caption_file:
                 with open(caption_file) as f:
                     captions = [f.read().strip()]
             if captions is None:
-                captions = ['']
-                logger.warning(f'Cound not find caption for {image_file}. Using empty caption.')
-            if self.directory_config['shuffle_tags'] and self.shuffle == 0: # backwards compatibility
+                captions = [""]
+                logger.warning(
+                    f"Cound not find caption for {image_file}. Using empty caption."
+                )
+            if (
+                self.directory_config["shuffle_tags"] and self.shuffle == 0
+            ):  # backwards compatibility
                 self.shuffle = 1
-            captions = shuffle_captions(captions, self.shuffle, self.shuffle_delimiter, self.directory_config['caption_prefix'])
-            empty_return = {'image_spec': [], 'mask_file': [], 'caption': [], 'ar_bucket': [], 'size_bucket': [], 'is_video': []}
-            if self.control_path:
-                empty_return['control_file'] = []
+            captions = shuffle_captions(
+                captions,
+                self.shuffle,
+                self.shuffle_delimiter,
+                self.directory_config["caption_prefix"],
+            )
+            empty_return = {
+                "image_spec": [],
+                "mask_file": [],
+                "caption": [],
+                "ar_bucket": [],
+                "size_bucket": [],
+                "is_video": [],
+            }
+            if self.source_path:
+                empty_return["source_file"] = []
+            if self.reference_path:
+                empty_return["reference_file"] = []
 
             if image_spec[0] is None:
                 tar_f = None
                 filepath_or_file = str(image_file)
             else:
                 tar_filename = image_spec[0]
-                tar_f = tarfile_map.setdefault(tar_filename, tarfile.TarFile(tar_filename))
+                tar_f = tarfile_map.setdefault(
+                    tar_filename, tarfile.TarFile(tar_filename)
+                )
                 filepath_or_file = tar_f.extractfile(str(image_file))
 
-            if image_file.suffix == '.webp':
+            if image_file.suffix == ".webp":
                 # Make sure this this object stays alive so it doesn't close the file on us.
                 reader = imageio.get_reader(filepath_or_file)
                 frames = reader.get_length()
                 if frames > 1:
-                    raise NotImplementedError('WebP videos are not supported.')
+                    raise NotImplementedError("WebP videos are not supported.")
             try:
                 if image_file.suffix in VIDEO_EXTENSIONS:
                     # 100% accurate frame count, but much slower.
@@ -655,45 +910,55 @@ class DirectoryDataset:
                     meta = imageio.v3.immeta(filepath_or_file)
                     first_frame = next(imageio.v3.imiter(filepath_or_file))
                     height, width = first_frame.shape[:2]
-                    assert self.framerate is not None, "Need model framerate but don't have it. This shouldn't happen. Is the framerate attribute on the model set?"
-                    frames = int(self.framerate * meta['duration'])
+                    assert (
+                        self.framerate is not None
+                    ), "Need model framerate but don't have it. This shouldn't happen. Is the framerate attribute on the model set?"
+                    frames = int(self.framerate * meta["duration"])
                 else:
                     pil_img = Image.open(filepath_or_file)
                     width, height = pil_img.size
                     frames = 1
             except Exception as e:
-                logger.warning(f'Media file {image_file} could not be opened. Skipping. The exception was: {e}')
+                logger.warning(
+                    f"Media file {image_file} could not be opened. Skipping. The exception was: {e}"
+                )
                 return empty_return
             finally:
-                if hasattr(filepath_or_file, 'close'):
+                if hasattr(filepath_or_file, "close"):
                     filepath_or_file.close()
 
-            is_video = (frames > 1)
+            is_video = frames > 1
             log_ar = np.log(width / height)
 
             if self.use_size_buckets:
                 size_bucket = self._find_closest_size_bucket(log_ar, frames, is_video)
                 if size_bucket is None:
-                    print(f'video with frames={frames} is being skipped because it is too short')
+                    print(
+                        f"video with frames={frames} is being skipped because it is too short"
+                    )
                     return empty_return
                 ar_bucket = None
             else:
                 ar_bucket = self._find_closest_ar_bucket(log_ar, frames, is_video)
                 if ar_bucket is None:
-                    print(f'video with frames={frames} is being skipped because it is too short')
+                    print(
+                        f"video with frames={frames} is being skipped because it is too short"
+                    )
                     return empty_return
                 size_bucket = None
 
             ret = {
-                'image_spec': [image_spec],
-                'mask_file': [example['mask_file'][0]],
-                'caption': [captions],
-                'ar_bucket': [ar_bucket],
-                'size_bucket': [size_bucket],
-                'is_video': [is_video],
+                "image_spec": [image_spec],
+                "mask_file": [example["mask_file"][0]],
+                "caption": [captions],
+                "ar_bucket": [ar_bucket],
+                "size_bucket": [size_bucket],
+                "is_video": [is_video],
             }
-            if self.control_path:
-                ret['control_file'] = [example['control_file'][0]]
+            if self.source_path:
+                ret["source_file"] = [example["source_file"][0]]
+            if self.reference_path:
+                ret["reference_file"] = [example["reference_file"][0]]
             return ret
 
         return fn
@@ -717,7 +982,7 @@ class DirectoryDataset:
     def _find_closest_size_bucket(self, log_ar, frames, is_video):
         # Best AR bucket is the one with the smallest AR difference in log space.
         ar_diffs = np.abs(log_ar - self.log_ars)
-        candidate_size_buckets = self.size_buckets[np.argsort(ar_diffs, kind='stable')]
+        candidate_size_buckets = self.size_buckets[np.argsort(ar_diffs, kind="stable")]
         # Find closest size bucket where the number of frames is greater than or equal to the bucket.
         # self.size_buckets was already sorted longest -> shortest frame length
         found = False
@@ -759,24 +1024,48 @@ class DirectoryDataset:
             result.extend(ar_bucket_dataset.get_size_bucket_datasets())
         return result
 
-    def cache_latents(self, map_fn, regenerate_cache=False, trust_cache=False, caching_batch_size=1):
-        print(f'caching latents: {self.path}')
-        datasets = self.size_bucket_datasets if self.use_size_buckets else self.ar_bucket_datasets
+    def cache_latents(
+        self, map_fn, regenerate_cache=False, trust_cache=False, caching_batch_size=1
+    ):
+        print(f"caching latents: {self.path}")
+        datasets = (
+            self.size_bucket_datasets
+            if self.use_size_buckets
+            else self.ar_bucket_datasets
+        )
         for ds in datasets:
-            ds.cache_latents(map_fn, regenerate_cache=regenerate_cache, trust_cache=trust_cache, caching_batch_size=caching_batch_size)
+            ds.cache_latents(
+                map_fn,
+                regenerate_cache=regenerate_cache,
+                trust_cache=trust_cache,
+                caching_batch_size=caching_batch_size,
+            )
 
-    def cache_text_embeddings(self, map_fn, i, regenerate_cache=False, caching_batch_size=1):
-        print(f'caching text embeddings: {self.path}')
-        datasets_list = self.size_bucket_datasets if self.use_size_buckets else self.ar_bucket_datasets
+    def cache_text_embeddings(
+        self, map_fn, i, regenerate_cache=False, caching_batch_size=1
+    ):
+        print(f"caching text embeddings: {self.path}")
+        datasets_list = (
+            self.size_bucket_datasets
+            if self.use_size_buckets
+            else self.ar_bucket_datasets
+        )
         for ds in datasets_list:
-            ds.cache_text_embeddings(map_fn, i, regenerate_cache=regenerate_cache, caching_batch_size=caching_batch_size)
+            ds.cache_text_embeddings(
+                map_fn,
+                i,
+                regenerate_cache=regenerate_cache,
+                caching_batch_size=caching_batch_size,
+            )
         # TODO: do this separately for is_video True and False for models that support it?
-        empty_caption_ds = datasets.Dataset.from_dict({'caption': [''], 'is_video': [False], 'image_spec': [(None, None)]})
+        empty_caption_ds = datasets.Dataset.from_dict(
+            {"caption": [""], "is_video": [False], "image_spec": [(None, None)]}
+        )
         uncond_text_embeddings_ds = _map_and_cache(
             empty_caption_ds,
             map_fn,
             cache_dir=self.cache_dir,
-            cache_file_prefix=f'uncond_text_embeddings_{i}_',
+            cache_file_prefix=f"uncond_text_embeddings_{i}_",
             regenerate_cache=regenerate_cache,
         )
         for size_bucket_ds in self.get_size_bucket_datasets():
@@ -801,7 +1090,7 @@ class Dataset:
             self.model.model_specific_dataset_config_validation(self.dataset_config)
 
         self.directory_datasets = []
-        for directory_config in dataset_config['directory']:
+        for directory_config in dataset_config["directory"]:
             directory_dataset = DirectoryDataset(
                 directory_config,
                 dataset_config,
@@ -811,19 +1100,32 @@ class Dataset:
             )
             self.directory_datasets.append(directory_dataset)
 
-    def post_init(self, data_parallel_rank, data_parallel_world_size, per_device_batch_size, gradient_accumulation_steps, per_device_batch_size_image):
+    def post_init(
+        self,
+        data_parallel_rank,
+        data_parallel_world_size,
+        per_device_batch_size,
+        gradient_accumulation_steps,
+        per_device_batch_size_image,
+    ):
         self.data_parallel_rank = data_parallel_rank
         self.data_parallel_world_size = data_parallel_world_size
         self.batch_size = per_device_batch_size * gradient_accumulation_steps
-        self.batch_size_image = per_device_batch_size_image * gradient_accumulation_steps
+        self.batch_size_image = (
+            per_device_batch_size_image * gradient_accumulation_steps
+        )
         self.global_batch_size = self.data_parallel_world_size * self.batch_size
-        self.global_batch_size_image = self.data_parallel_world_size * self.batch_size_image
+        self.global_batch_size_image = (
+            self.data_parallel_world_size * self.batch_size_image
+        )
 
         # group same size_bucket together
         datasets_by_size_bucket = defaultdict(list)
         for directory_dataset in self.directory_datasets:
             for size_bucket_dataset in directory_dataset.get_size_bucket_datasets():
-                datasets_by_size_bucket[size_bucket_dataset.size_bucket].append(size_bucket_dataset)
+                datasets_by_size_bucket[size_bucket_dataset.size_bucket].append(
+                    size_bucket_dataset
+                )
         self.buckets = []
         for datasets in datasets_by_size_bucket.values():
             self.buckets.append(ConcatenatedBatchedDataset(datasets))
@@ -833,7 +1135,7 @@ class Dataset:
 
         iteration_order = []
         for i, bucket in enumerate(self.buckets):
-            iteration_order.extend([i]*(len(bucket)))
+            iteration_order.extend([i] * (len(bucket)))
         shuffle_with_seed(iteration_order, 0)
         cumulative_sums = [0] * len(self.buckets)
         for k, dataset_idx in enumerate(iteration_order):
@@ -841,11 +1143,11 @@ class Dataset:
             cumulative_sums[dataset_idx] += 1
         self.iteration_order = iteration_order
         if DEBUG:
-            print(f'Dataset iteration_order: {self.iteration_order}')
+            print(f"Dataset iteration_order: {self.iteration_order}")
 
         self.post_init_called = True
 
-        if subsample_ratio := self.dataset_config.get('subsample_ratio', None):
+        if subsample_ratio := self.dataset_config.get("subsample_ratio", None):
             new_len = int(len(self) * subsample_ratio)
             self.iteration_order = self.iteration_order[:new_len]
 
@@ -860,10 +1162,10 @@ class Dataset:
         assert self.post_init_called
         i, j = self.iteration_order[idx]
         examples = self.buckets[i][j]
-        start_idx = self.data_parallel_rank*self.batch_size
-        examples_for_this_dp_rank = examples[start_idx:start_idx+self.batch_size]
+        start_idx = self.data_parallel_rank * self.batch_size
+        examples_for_this_dp_rank = examples[start_idx : start_idx + self.batch_size]
         if DEBUG:
-            print((start_idx, start_idx+self.batch_size))
+            print((start_idx, start_idx + self.batch_size))
         batch = self._collate(examples_for_this_dp_rank)
         return batch
 
@@ -872,7 +1174,7 @@ class Dataset:
     def _collate(self, examples):
         ret = {}
         for key in examples[0]:
-            if key == 'mask':
+            if key == "mask":
                 continue  # mask is handled specially below
             features = [example[key] for example in examples]
             if torch.is_tensor(features[0]):
@@ -882,7 +1184,7 @@ class Dataset:
                     features = torch.stack(features)
             ret[key] = features
         # Only some items in the batch might have valid mask.
-        masks = [example['mask'] for example in examples]
+        masks = [example["mask"] for example in examples]
         # See if we have any valid masks. If we do, they should all have the same shape.
         shape = None
         for mask in masks:
@@ -894,30 +1196,54 @@ class Dataset:
             for i, mask in enumerate(masks):
                 if mask is None:
                     masks[i] = torch.ones(shape, dtype=torch.float16)
-            ret['mask'] = torch.stack(masks)
+            ret["mask"] = torch.stack(masks)
         else:
             # We can leave the batch mask as None and the loss_fn will skip masking entirely.
-            ret['mask'] = None
+            ret["mask"] = None
         return ret
 
     def cache_metadata(self, regenerate_cache=False, trust_cache=False):
         for ds in self.directory_datasets:
-            ds.cache_metadata(regenerate_cache=regenerate_cache, trust_cache=trust_cache)
+            ds.cache_metadata(
+                regenerate_cache=regenerate_cache, trust_cache=trust_cache
+            )
 
-    def cache_latents(self, map_fn, regenerate_cache=False, trust_cache=False, caching_batch_size=1):
+    def cache_latents(
+        self, map_fn, regenerate_cache=False, trust_cache=False, caching_batch_size=1
+    ):
         for ds in self.directory_datasets:
-            ds.cache_latents(map_fn, regenerate_cache=regenerate_cache, trust_cache=trust_cache, caching_batch_size=caching_batch_size)
+            ds.cache_latents(
+                map_fn,
+                regenerate_cache=regenerate_cache,
+                trust_cache=trust_cache,
+                caching_batch_size=caching_batch_size,
+            )
 
-    def cache_text_embeddings(self, map_fn, i, regenerate_cache=False, caching_batch_size=1):
+    def cache_text_embeddings(
+        self, map_fn, i, regenerate_cache=False, caching_batch_size=1
+    ):
         for ds in self.directory_datasets:
-            ds.cache_text_embeddings(map_fn, i, regenerate_cache=regenerate_cache, caching_batch_size=caching_batch_size)
+            ds.cache_text_embeddings(
+                map_fn,
+                i,
+                regenerate_cache=regenerate_cache,
+                caching_batch_size=caching_batch_size,
+            )
 
 
-def _cache_fn(datasets, queue, preprocess_media_file_fn, num_text_encoders, regenerate_cache, trust_cache, caching_batch_size):
+def _cache_fn(
+    datasets,
+    queue,
+    preprocess_media_file_fn,
+    num_text_encoders,
+    regenerate_cache,
+    trust_cache,
+    caching_batch_size,
+):
     # Dataset map() starts a bunch of processes. Make sure torch uses a limited number of threads
     # to avoid CPU contention.
     # TODO: if we ever change Datasets map to use spawn instead of fork, this might not work.
-    #torch.set_num_threads(os.cpu_count() // NUM_PROC)
+    # torch.set_num_threads(os.cpu_count() // NUM_PROC)
     # HF Datasets map can randomly hang if this is greater than one (???)
     # See https://github.com/pytorch/pytorch/issues/10996
     # Alternatively, we could try fixing this by using spawn instead of fork.
@@ -929,14 +1255,19 @@ def _cache_fn(datasets, queue, preprocess_media_file_fn, num_text_encoders, rege
     pipes = {}
 
     def latents_map_fn(example, rank):
-        is_edit_dataset = ('control_file' in example)
-        first_size_bucket = example['size_bucket'][0]
+        is_edit_dataset = "source_file" in example
+        first_size_bucket = example["size_bucket"][0]
         tensors_and_masks = []
         image_specs = []
         captions = []
         control_tensors_and_masks = []
         for i, (image_spec, mask_path, size_bucket, caption) in enumerate(
-            zip(example['image_spec'], example['mask_file'], example['size_bucket'], example['caption'])
+            zip(
+                example["image_spec"],
+                example["mask_file"],
+                example["size_bucket"],
+                example["caption"],
+            )
         ):
             assert size_bucket == first_size_bucket
             items = preprocess_media_file_fn(image_spec, mask_path, size_bucket)
@@ -944,8 +1275,10 @@ def _cache_fn(datasets, queue, preprocess_media_file_fn, num_text_encoders, rege
             image_specs.extend([image_spec] * len(items))
             captions.extend([caption] * len(items))
             if is_edit_dataset:
-                control_file = example['control_file'][i]
-                control_items = preprocess_media_file_fn((None, control_file), None, size_bucket)
+                source_file = example["source_file"][i]
+                control_items = preprocess_media_file_fn(
+                    (None, source_file), None, size_bucket
+                )
                 assert len(control_items) == 1
                 assert len(items) == 1
                 control_tensors_and_masks.append(control_items[0])
@@ -954,13 +1287,24 @@ def _cache_fn(datasets, queue, preprocess_media_file_fn, num_text_encoders, rege
 
         if len(tensors_and_masks) == 0:
             assert not is_edit_dataset
-            return {'latents': [], 'mask': [], 'image_spec': [], 'caption': []}
+            return {"latents": [], "mask": [], "image_spec": [], "caption": []}
 
-        caching_batch_size = len(example['image_spec'])
+        caching_batch_size = len(example["image_spec"])
         results = defaultdict(list)
         for i in range(0, len(tensors_and_masks), caching_batch_size):
-            tensor = torch.stack([t[0] for t in tensors_and_masks[i:i+caching_batch_size]])
-            c_tensor = torch.stack([t[0] for t in control_tensors_and_masks[i:i+caching_batch_size]]) if is_edit_dataset else None
+            tensor = torch.stack(
+                [t[0] for t in tensors_and_masks[i : i + caching_batch_size]]
+            )
+            c_tensor = (
+                torch.stack(
+                    [
+                        t[0]
+                        for t in control_tensors_and_masks[i : i + caching_batch_size]
+                    ]
+                )
+                if is_edit_dataset
+                else None
+            )
             parent_conn, child_conn = pipes.setdefault(rank, mp.Pipe(duplex=False))
             queue.put((0, tensor, c_tensor, child_conn))
             result = parent_conn.recv()  # dict
@@ -969,24 +1313,46 @@ def _cache_fn(datasets, queue, preprocess_media_file_fn, num_text_encoders, rege
         # concatenate the list of tensors at each key into one batched tensor
         for k, v in results.items():
             results[k] = torch.cat(v)
-        results['image_spec'] = image_specs
-        results['mask'] = [t[1] for t in tensors_and_masks]
-        results['caption'] = captions
+        results["image_spec"] = image_specs
+        results["mask"] = [t[1] for t in tensors_and_masks]
+        results["caption"] = captions
         return results
 
     for ds in datasets:
-        ds.cache_latents(latents_map_fn, regenerate_cache=regenerate_cache, trust_cache=trust_cache, caching_batch_size=caching_batch_size)
+        ds.cache_latents(
+            latents_map_fn,
+            regenerate_cache=regenerate_cache,
+            trust_cache=trust_cache,
+            caching_batch_size=caching_batch_size,
+        )
 
     for text_encoder_idx in range(num_text_encoders):
+
         def text_embedding_map_fn(example, rank):
             parent_conn, child_conn = pipes.setdefault(rank, mp.Pipe(duplex=False))
-            control_file = example['control_file'] if 'control_file' in example else None
-            queue.put((text_encoder_idx+1, example['caption'], example['is_video'], control_file, child_conn))
+            reference_file = (
+                example["reference_file"] if "reference_file" in example else None
+            )
+            queue.put(
+                (
+                    text_encoder_idx + 1,
+                    example["caption"],
+                    example["is_video"],
+                    reference_file,
+                    child_conn,
+                )
+            )
             result = parent_conn.recv()  # dict
-            result['image_spec'] = example['image_spec']
+            result["image_spec"] = example["image_spec"]
             return result
+
         for ds in datasets:
-            ds.cache_text_embeddings(text_embedding_map_fn, text_encoder_idx+1, regenerate_cache=regenerate_cache, caching_batch_size=caching_batch_size)
+            ds.cache_text_embeddings(
+                text_embedding_map_fn,
+                text_encoder_idx + 1,
+                regenerate_cache=regenerate_cache,
+                caching_batch_size=caching_batch_size,
+            )
 
     # signal that we're done
     queue.put(None)
@@ -995,16 +1361,20 @@ def _cache_fn(datasets, queue, preprocess_media_file_fn, num_text_encoders, rege
 # Helper class to make caching multiple datasets more efficient by moving
 # models to GPU as few times as needed.
 class DatasetManager:
-    def __init__(self, model, regenerate_cache=False, trust_cache=False, caching_batch_size=1):
+    def __init__(
+        self, model, regenerate_cache=False, trust_cache=False, caching_batch_size=1
+    ):
         self.model = model
         self.vae = self.model.get_vae()
         self.text_encoders = self.model.get_text_encoders()
         self.submodels = [self.vae] + list(self.text_encoders)
         self.call_vae_fn = self.model.get_call_vae_fn(self.vae)
-        self.call_text_encoder_fns = [self.model.get_call_text_encoder_fn(text_encoder) for text_encoder in self.text_encoders]
-        self.te_fn_requires_control_file = [
-            len(signature(fn).parameters) == 3
-            for fn in self.call_text_encoder_fns
+        self.call_text_encoder_fns = [
+            self.model.get_call_text_encoder_fn(text_encoder)
+            for text_encoder in self.text_encoders
+        ]
+        self.te_fn_requires_reference_file = [
+            len(signature(fn).parameters) == 3 for fn in self.call_text_encoder_fns
         ]
         self.regenerate_cache = regenerate_cache
         self.trust_cache = trust_cache
@@ -1024,7 +1394,9 @@ class DatasetManager:
             queue = [manager.Queue()]
         else:
             queue = [None]
-        torch.distributed.broadcast_object_list(queue, src=0, group=dist.get_world_group())
+        torch.distributed.broadcast_object_list(
+            queue, src=0, group=dist.get_world_group()
+        )
         queue = queue[0]
 
         # start up a process to run through the dataset caching flow
@@ -1039,7 +1411,7 @@ class DatasetManager:
                     self.regenerate_cache,
                     self.trust_cache,
                     self.caching_batch_size,
-                )
+                ),
             )
             process.start()
 
@@ -1057,11 +1429,11 @@ class DatasetManager:
             # Free memory in all unneeded submodels. This is easier than trying to delete every reference.
             # TODO: check if this is actually freeing memory.
             for model in self.submodels:
-                if self.model.name == 'sdxl' and model is self.vae:
+                if self.model.name == "sdxl" and model is self.vae:
                     # If full fine tuning SDXL, we need to keep the VAE weights around for saving the model.
-                    model.to('cpu')
+                    model.to("cpu")
                 else:
-                    model.to('meta')
+                    model.to("meta")
 
         dist.barrier()
         if is_main_process():
@@ -1071,18 +1443,18 @@ class DatasetManager:
         for ds in self.datasets:
             ds.cache_metadata(trust_cache=True)
             ds.cache_latents(None, trust_cache=True)
-            for i in range(1, len(self.text_encoders)+1):
+            for i in range(1, len(self.text_encoders) + 1):
                 ds.cache_text_embeddings(None, i)
 
     @torch.no_grad()
     def _handle_task(self, task):
         id = task[0]
         # moved needed submodel to cuda, and everything else to cpu
-        if next(self.submodels[id].parameters()).device.type != 'cuda':
+        if next(self.submodels[id].parameters()).device.type != "cuda":
             for i, submodel in enumerate(self.submodels):
                 if i != id:
-                    submodel.to('cpu')
-            self.submodels[id].to('cuda')
+                    submodel.to("cpu")
+            self.submodels[id].to("cuda")
         if id == 0:
             tensor, control_tensor, pipe = task[1:]
             if control_tensor is not None:
@@ -1091,11 +1463,11 @@ class DatasetManager:
             else:
                 results = self.call_vae_fn(tensor)
         elif id > 0:
-            caption, is_video, control_file, pipe = task[1:]
+            caption, is_video, reference_file, pipe = task[1:]
             args = [caption, is_video]
             idx = id - 1
-            if self.te_fn_requires_control_file[idx]:
-                args.append(control_file)
+            if self.te_fn_requires_reference_file[idx]:
+                args.append(reference_file)
             results = self.call_text_encoder_fns[idx](*args)
         else:
             raise RuntimeError()
@@ -1105,9 +1477,9 @@ class DatasetManager:
         cpu_results = {}
         for k, v in results.items():
             if isinstance(v, (list, tuple)):
-                cpu_results[k] = [x.to('cpu') for x in v]
+                cpu_results[k] = [x.to("cpu") for x in v]
             else:
-                cpu_results[k] = v.to('cpu')
+                cpu_results[k] = v.to("cpu")
         pipe.send(cpu_results)
 
 
@@ -1116,8 +1488,26 @@ def split_batch(batch, pieces):
     features, label = batch
     split_size = features[0].size(0) // pieces
     # The tuples passed to Deepspeed need to only contain tensors. For None (e.g. mask, or optional conditioning), convert to empty tensor.
-    split_features = zip(*(torch.split(tensor, split_size) if tensor is not None else [torch.tensor([])]*pieces for tensor in features))
-    split_label = zip(*(torch.split(tensor, split_size) if tensor is not None else [torch.tensor([])]*pieces for tensor in label))
+    split_features = zip(
+        *(
+            (
+                torch.split(tensor, split_size)
+                if tensor is not None
+                else [torch.tensor([])] * pieces
+            )
+            for tensor in features
+        )
+    )
+    split_label = zip(
+        *(
+            (
+                torch.split(tensor, split_size)
+                if tensor is not None
+                else [torch.tensor([])] * pieces
+            )
+            for tensor in label
+        )
+    )
     # Deepspeed works with a tuple of (features, labels).
     return list(zip(split_features, split_label))
 
@@ -1141,12 +1531,19 @@ def split_batch(batch, pieces):
 # pipeline parallel training. Iterates indefinitely (deepspeed requirement). Keeps track of epoch.
 # Updates epoch as soon as the final batch is returned (notably different from qlora-pipe).
 class PipelineDataLoader:
-    def __init__(self, dataset, model_engine, gradient_accumulation_steps, model, num_dataloader_workers=1):
+    def __init__(
+        self,
+        dataset,
+        model_engine,
+        gradient_accumulation_steps,
+        model,
+        num_dataloader_workers=1,
+    ):
         if len(dataset) == 0:
             raise RuntimeError(
-                'Processed dataset was empty. Probably caused by rounding down for each size bucket.\n'
-                'Try decreasing the global batch size, or increasing num_repeats.\n'
-                f'The dataset config that triggered this error was:\n{dataset.dataset_config}'
+                "Processed dataset was empty. Probably caused by rounding down for each size bucket.\n"
+                "Try decreasing the global batch size, or increasing num_repeats.\n"
+                f"The dataset config that triggered this error was:\n{dataset.dataset_config}"
             )
         self.model = model
         self.dataset = dataset
@@ -1212,7 +1609,9 @@ class PipelineDataLoader:
 
     def _pull_batches_from_dataloader(self):
         for batch in self.dataloader:
-            features, label = self.model.prepare_inputs(batch, timestep_quantile=self.eval_quantile)
+            features, label = self.model.prepare_inputs(
+                batch, timestep_quantile=self.eval_quantile
+            )
             target, mask = label
             # The target depends on the noise, so we must broadcast it from the first stage to the last.
             # NOTE: I had to patch the pipeline parallel TrainSchedule so that the LoadMicroBatch commands
@@ -1220,7 +1619,9 @@ class PipelineDataLoader:
             target = self._broadcast_target(target)
             label = (target, mask)
             self.num_batches_pulled += 1
-            for micro_batch in split_batch((features, label), self.gradient_accumulation_steps):
+            for micro_batch in split_batch(
+                (features, label), self.gradient_accumulation_steps
+            ):
                 yield micro_batch
 
     def _broadcast_target(self, target):
@@ -1235,7 +1636,7 @@ class PipelineDataLoader:
         dest_rank = grid.stage_to_global(model_engine.num_stages - 1)
         assert src_rank in grid.pp_group
         assert dest_rank in grid.pp_group
-        target = target.to('cuda')  # must be on GPU to broadcast
+        target = target.to("cuda")  # must be on GPU to broadcast
 
         if model_engine.is_first_stage():
             dist.send(target, dest_rank)
@@ -1257,16 +1658,16 @@ class PipelineDataLoader:
 
     def state_dict(self):
         return {
-            'epoch': self.epoch,
-            'num_batches_pulled': self.num_batches_pulled,
+            "epoch": self.epoch,
+            "num_batches_pulled": self.num_batches_pulled,
         }
 
     def load_state_dict(self, state_dict):
         assert not self.iter_called
-        self.epoch = state_dict['epoch']
+        self.epoch = state_dict["epoch"]
         # -1 because by preloading the next micro_batch, it's always going to have one more batch
         # pulled than the actual number of batches iterated by the caller.
-        self.num_batches_pulled = state_dict['num_batches_pulled'] - 1
+        self.num_batches_pulled = state_dict["num_batches_pulled"] - 1
         self._create_dataloader(skip_first_n_batches=self.num_batches_pulled)
         self.data = self._pull_batches_from_dataloader()
         # Recreate the dataloader after the first pass so that it won't skip
@@ -1288,32 +1689,45 @@ class SkipFirstNSampler(torch.utils.data.Sampler):
             yield i
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from utils import common
+
     common.is_main_process = lambda: True
     from contextlib import contextmanager
+
     @contextmanager
     def _zero_first():
         yield
+
     common.zero_first = _zero_first
 
     from utils import dataset as dataset_util
+
     dataset_util.DEBUG = True
 
     from models import flux
-    model = flux.CustomFluxPipeline.from_pretrained('/data2/imagegen_models/FLUX.1-dev', torch_dtype=torch.bfloat16)
-    model.model_config = {'guidance': 1.0, 'dtype': torch.bfloat16}
+
+    model = flux.CustomFluxPipeline.from_pretrained(
+        "/data2/imagegen_models/FLUX.1-dev", torch_dtype=torch.bfloat16
+    )
+    model.model_config = {"guidance": 1.0, "dtype": torch.bfloat16}
 
     import toml
+
     dataset_manager = dataset_util.DatasetManager(model)
-    with open('/home/anon/code/diffusion-pipe-configs/datasets/tiny1.toml') as f:
+    with open("/home/anon/code/diffusion-pipe-configs/datasets/tiny1.toml") as f:
         dataset_config = toml.load(f)
     train_data = dataset_util.Dataset(dataset_config, model)
     dataset_manager.register(train_data)
     dataset_manager.cache()
 
-    train_data.post_init(data_parallel_rank=0, data_parallel_world_size=1, per_device_batch_size=1, gradient_accumulation_steps=2)
-    print(f'Dataset length: {len(train_data)}')
+    train_data.post_init(
+        data_parallel_rank=0,
+        data_parallel_world_size=1,
+        per_device_batch_size=1,
+        gradient_accumulation_steps=2,
+    )
+    print(f"Dataset length: {len(train_data)}")
 
     for item in train_data:
         pass


### PR DESCRIPTION
## Summary
- Allow datasets to specify separate `source_path` and `reference_path` directories for edit training
- Encode source images as UNet conditioning while passing reference images to the text encoder
- Document new dataset options for image-to-image editing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c821c152a48323a3536d074927f37e