### PR TITLE
Add utilities for Qwen Image Edit triplet training

### DIFF
--- a/inference_triplet_ref.py
+++ b/inference_triplet_ref.py
@@ -1,0 +1,93 @@
+import sys
+from pathlib import Path
+
+import torch
+from PIL import Image, ImageOps
+from diffusers import QwenImageEditPipeline
+
+
+def load_rgb(path: str) -> Image.Image:
+    img = Image.open(path)
+    if img.mode == "RGBA":
+        bg = Image.new("RGBA", img.size, (0, 0, 0, 255))
+        img = Image.alpha_composite(bg, img)
+    return img.convert("RGB")
+
+
+def letterbox_to_height(img: Image.Image, height: int, pad_color=(0, 0, 0)) -> Image.Image:
+    w, h = img.size
+    scale = height / h
+    new_w = max(1, int(round(w * scale)))
+    resized = img.resize((new_w, height), Image.LANCZOS)
+    if new_w != height:
+        pad_left = (height - new_w) // 2
+        pad_right = height - new_w - pad_left
+        resized = ImageOps.expand(resized, border=(pad_left, 0, pad_right, 0), fill=pad_color)
+    return resized
+
+
+def make_composite(left_img: Image.Image, right_img: Image.Image, height: int = 1024):
+    left = letterbox_to_height(left_img, height)
+    right = letterbox_to_height(right_img, height)
+    canvas = Image.new("RGB", (left.width + right.width, height), (0, 0, 0))
+    canvas.paste(left, (0, 0))
+    canvas.paste(right, (left.width, 0))
+    return canvas, left.width, height
+
+
+def run(
+    model: str = "Qwen/Qwen-Image-Edit",
+    lora: str = None,
+    source_path: str = None,
+    ref_path: str = None,
+    out_path: str = "edited.png",
+    height: int = 1024,
+    steps: int = 50,
+):
+    if source_path is None or ref_path is None:
+        raise ValueError("source_path and ref_path must be provided")
+
+    source = load_rgb(source_path)
+    reference = load_rgb(ref_path)
+    composite, left_width, height = make_composite(source, reference, height)
+
+    pipe = QwenImageEditPipeline.from_pretrained(model, torch_dtype=torch.bfloat16).to("cuda")
+    if lora:
+        pipe.load_lora_weights(lora)
+
+    result = pipe(
+        image=composite,
+        prompt=" ",
+        negative_prompt=" ",
+        true_cfg_scale=1.0,
+        num_inference_steps=steps,
+        generator=torch.manual_seed(0),
+    ).images[0]
+
+    edited_left = result.crop((0, 0, left_width, height))
+    output_path = Path(out_path)
+    edited_left.save(output_path)
+    print("Saved:", output_path.resolve())
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 4:
+        raise SystemExit(
+            "Usage: python inference_triplet_ref.py <lora_path> <source.png> <reference.png> [out.png] [height] [steps]"
+        )
+
+    lora_path = sys.argv[1]
+    source_img = sys.argv[2]
+    reference_img = sys.argv[3]
+    output = sys.argv[4] if len(sys.argv) > 4 else "edited.png"
+    height = int(sys.argv[5]) if len(sys.argv) > 5 else 1024
+    steps = int(sys.argv[6]) if len(sys.argv) > 6 else 40
+
+    run(
+        lora=lora_path,
+        source_path=source_img,
+        ref_path=reference_img,
+        out_path=output,
+        height=height,
+        steps=steps,
+    )

--- a/tools/prepare_qwen_edit_triplet.py
+++ b/tools/prepare_qwen_edit_triplet.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+from PIL import Image, ImageOps
+
+
+def load_rgba(path: Path) -> Image.Image:
+    im = Image.open(path).convert("RGBA")
+    bg = Image.new("RGBA", im.size, (0, 0, 0, 255))
+    return Image.alpha_composite(bg, im).convert("RGB")
+
+
+def letterbox_to_height(img: Image.Image, height: int, pad_color=(0, 0, 0)) -> Image.Image:
+    w, h = img.size
+    scale = height / h
+    new_w = max(1, int(round(w * scale)))
+    img_resized = img.resize((new_w, height), Image.LANCZOS)
+    if new_w != height:
+        pad_left = (height - new_w) // 2
+        pad_right = height - new_w - pad_left
+        img_resized = ImageOps.expand(
+            img_resized,
+            border=(pad_left, 0, pad_right, 0),
+            fill=pad_color,
+        )
+    return img_resized
+
+
+def make_composite(
+    left_img: Image.Image,
+    right_img: Image.Image,
+    height: int = 1024,
+    sep: int = 0,
+    pad_color=(0, 0, 0),
+) -> Image.Image:
+    left = letterbox_to_height(left_img, height, pad_color)
+    right = letterbox_to_height(right_img, height, pad_color)
+    width = left.width + (sep if sep > 0 else 0) + right.width
+    canvas = Image.new("RGB", (width, height), pad_color)
+    x = 0
+    canvas.paste(left, (x, 0))
+    x += left.width
+    if sep > 0:
+        x += sep
+    canvas.paste(right, (x, 0))
+    return canvas
+
+
+def sort_key(path: Path):
+    stem = path.stem
+    try:
+        return (0, int(stem))
+    except ValueError:
+        return (1, stem)
+
+
+def format_base(path: Path) -> str:
+    stem = path.stem
+    try:
+        return f"{int(stem):04d}"
+    except ValueError:
+        return stem
+
+
+def main(src_root: str, dst_root: str, height: int = 1024) -> None:
+    src = Path(src_root)
+    dst = Path(dst_root)
+    out_images = dst / "train" / "images"
+    out_control = dst / "train" / "control"
+    out_images.mkdir(parents=True, exist_ok=True)
+    out_control.mkdir(parents=True, exist_ok=True)
+
+    input_dir = src / "input"
+    ref_dir = src / "breast"
+    target_dir = src / "output"
+
+    inputs = sorted(input_dir.glob("*.png"), key=sort_key)
+    refs = sorted(ref_dir.glob("*.png"), key=sort_key)
+    outs = sorted(target_dir.glob("*.png"), key=sort_key)
+    if not (len(inputs) == len(refs) == len(outs) and len(inputs) > 0):
+        raise ValueError("Mismatched counts.")
+
+    for pin, pref, pout in zip(inputs, refs, outs):
+        left_src = Image.open(pin).convert("RGB")
+        right_ref = load_rgba(pref)
+        left_tgt = Image.open(pout).convert("RGB")
+
+        control = make_composite(left_src, right_ref, height, sep=0)
+        target = make_composite(left_tgt, right_ref, height, sep=0)
+
+        base = format_base(pin)
+
+        control.save(out_control / f"{base}.png")
+        target.save(out_images / f"{base}.png")
+        (out_images / f"{base}.txt").write_text(" ")
+
+    print(f"Done. Wrote composites to: {dst.resolve()}")
+
+
+if __name__ == "__main__":
+    src_root = sys.argv[1]
+    dst_root = sys.argv[2]
+    height = int(sys.argv[3]) if len(sys.argv) > 3 else 1024
+    main(src_root, dst_root, height=height)

--- a/train_configs/train_lora_qwen_edit_ref.yaml
+++ b/train_configs/train_lora_qwen_edit_ref.yaml
@@ -1,0 +1,26 @@
+# --- paths ---
+pretrained_model_name_or_path: "Qwen/Qwen-Image-Edit"
+img_dir: "/workspace/qwen-image-training/extracted_dataset/train/images"
+control_dir: "/workspace/qwen-image-training/extracted_dataset/train/control"
+output_dir: "/workspace/qwen-image-training/outputs/qwen_edit_lora_ref"
+
+# --- training ---
+resolution: 1024
+train_batch_size: 2
+gradient_accumulation_steps: 2
+max_train_steps: 8000
+learning_rate: 1e-4
+lr_scheduler: cosine
+lr_warmup_steps: 200
+seed: 42
+mixed_precision: bf16
+
+# --- LoRA config ---
+lora_rank: 32
+lora_alpha: 32
+lora_dropout: 0.0
+
+# --- misc ---
+checkpointing_steps: 500
+validation_steps: 1000
+log_steps: 50


### PR DESCRIPTION
## Summary
- add a dataset preparation script that builds composite control/target images for triplet-based Qwen-Image-Edit LoRA training
- provide a ready-to-use training configuration targeting the composite dataset layout
- add an inference helper that loads the LoRA, feeds source/reference composites, and crops the edited result

## Testing
- `python -m compileall tools/prepare_qwen_edit_triplet.py inference_triplet_ref.py`


------
https://chatgpt.com/codex/tasks/task_e_68caf69eecf883238dac11c5ccb1547c