### PR TITLE
Add logging directory to LoRA training config

### DIFF
--- a/train_configs/train_lora_qwen_edit_ref.yaml
+++ b/train_configs/train_lora_qwen_edit_ref.yaml
@@ -3,6 +3,7 @@ pretrained_model_name_or_path: "Qwen/Qwen-Image-Edit"
 img_dir: "/workspace/qwen-image-training/extracted_dataset/train/images"
 control_dir: "/workspace/qwen-image-training/extracted_dataset/train/control"
 output_dir: "/workspace/qwen-image-training/outputs/qwen_edit_lora_ref"
+logging_dir: "logs"
 
 # --- training ---
 resolution: 1024


### PR DESCRIPTION
## Summary
- add a `logging_dir` entry to the LoRA training YAML so the trainer can resolve the logging path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb02db41008323a997320485e89cba