### PR TITLE
Add tensorboard logging configuration

### DIFF
--- a/train_configs/train_lora_qwen_edit_ref.yaml
+++ b/train_configs/train_lora_qwen_edit_ref.yaml
@@ -4,6 +4,7 @@ img_dir: "/workspace/qwen-image-training/extracted_dataset/train/images"
 control_dir: "/workspace/qwen-image-training/extracted_dataset/train/control"
 output_dir: "/workspace/qwen-image-training/outputs/qwen_edit_lora_ref"
 logging_dir: "logs"
+report_to: "tensorboard"
 
 # --- training ---
 resolution: 1024


### PR DESCRIPTION
## Summary
- add the missing `report_to` key to the LoRA training config so the trainer can log to TensorBoard by default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb079eb5148323927e16e8c4bcdc29